### PR TITLE
0007 add logout button

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$USER_HOME$/Library/Caches/Google/AndroidStudioPreview2022.1/device-explorer/google-pixel_3-915X1UW14/data/data/com.realityexpander.tasky/files/datastore/app-settings.json" charset="US-ASCII" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,6 @@ dependencies {
     implementation "androidx.room:room-ktx:2.4.3"
 
     // Proto DataStore
-    //implementation "androidx.datastore:datastore:1.0.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,8 @@ dependencies {
     implementation "androidx.room:room-ktx:2.4.3"
 
     // Proto DataStore
-    implementation "androidx.datastore:datastore:1.0.0"
+    //implementation "androidx.datastore:datastore:1.0.0"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 
     // SplashScreen

--- a/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
@@ -26,7 +26,11 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlin.system.exitProcess
 
-val Context.dataStore by dataStore("app-settings.json", AppSettingsSerializer)
+val Context.dataStore by
+    dataStore(
+        "app-settings.data",
+        AppSettingsSerializer(encrypted = true)
+    )
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.datastore.dataStore
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.realityexpander.tasky.auth_feature.presentation.splash_screen.MainActivityViewModel
 import com.realityexpander.tasky.core.data.settings.AppSettingsSerializer
-import com.realityexpander.tasky.core.data.settings.setSettingsInitialized
+import com.realityexpander.tasky.core.data.settings.saveSettingsInitialized
 import com.realityexpander.tasky.core.presentation.theme.TaskyTheme
 import com.realityexpander.tasky.destinations.AgendaScreenDestination
 import com.realityexpander.tasky.destinations.LoginScreenDestination
@@ -59,7 +59,7 @@ class MainActivity : ComponentActivity() {
 
                         // Confirm the settings file is created and initialized
                         if (!appSettings.isSettingsInitialized) {
-                            context.dataStore.setSettingsInitialized(true)
+                            context.dataStore.saveSettingsInitialized(true)
                         }
 
                         // Set user is logged-in status

--- a/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : ComponentActivity() {
                             context.dataStore.saveSettingsInitialized(true)
                         }
 
-                        // Set user is logged-in status
+                        // Set user logged-in status
                         viewModel.onSetAuthInfo(appSettings.authInfo)
                     }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaEvent.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaEvent.kt
@@ -3,33 +3,27 @@ package com.realityexpander.tasky.agenda_feature.presentation.agenda_screen
 import com.realityexpander.tasky.core.presentation.common.util.UiText
 
 sealed interface AgendaEvent {
+    data class SetIsLoaded(val isLoaded: Boolean) : AgendaEvent
     data class ShowProgressIndicator(val isShowing: Boolean) : AgendaEvent
 
-    data class UpdateUsername(val username: String) : AgendaEvent
-    data class UpdateEmail(val email: String) : AgendaEvent
-    data class UpdatePassword(val password: String) : AgendaEvent
-    data class UpdateConfirmPassword(val confirmPassword: String) : AgendaEvent
-
     object ValidateUsername : AgendaEvent
-
     data class IsPasswordsMatch(val isMatch: Boolean) : AgendaEvent
 
     object ShowInvalidUsernameMessage : AgendaEvent
 
-    data class Register(
+    data class UnknownError(val message: UiText) : AgendaEvent
+
+    data class CreateEvent(
             val username: String,
             val email: String,
             val password: String,
             val confirmPassword: String
         ) : AgendaEvent
-    data class RegisterSuccess(val message: UiText) : AgendaEvent
-    data class RegisterError(val message: UiText) : AgendaEvent
-
-    data class UnknownError(val message: UiText) : AgendaEvent
-
+    data class CreateEventSuccess(val message: UiText) : AgendaEvent
+    data class CreateEventError(val message: UiText) : AgendaEvent
 
 
     object ToggleLogoutDropdown : AgendaEvent
     object Logout : AgendaEvent
-    data class SetIsLoaded(val isLoaded: Boolean) : AgendaEvent
+
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaEvent.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaEvent.kt
@@ -3,30 +3,18 @@ package com.realityexpander.tasky.agenda_feature.presentation.agenda_screen
 import com.realityexpander.tasky.core.presentation.common.util.UiText
 
 sealed interface AgendaEvent {
-    data class SetIsLoading(val isLoading: Boolean) : AgendaEvent
+    data class ShowProgressIndicator(val isShowing: Boolean) : AgendaEvent
 
     data class UpdateUsername(val username: String) : AgendaEvent
     data class UpdateEmail(val email: String) : AgendaEvent
     data class UpdatePassword(val password: String) : AgendaEvent
     data class UpdateConfirmPassword(val confirmPassword: String) : AgendaEvent
-    data class SetIsPasswordVisible(val isVisible: Boolean) : AgendaEvent
 
     object ValidateUsername : AgendaEvent
-    object ValidateEmail : AgendaEvent
-    object ValidatePassword : AgendaEvent
-    object ValidateConfirmPassword : AgendaEvent
-    object ValidatePasswordsMatch : AgendaEvent
 
-    data class IsValidUsername(val isValid: Boolean) : AgendaEvent
-    data class IsValidEmail(val isValid: Boolean) : AgendaEvent
-    data class IsValidPassword(val isValid: Boolean) : AgendaEvent
-    data class IsValidConfirmPassword(val isValid: Boolean) : AgendaEvent
     data class IsPasswordsMatch(val isMatch: Boolean) : AgendaEvent
 
     object ShowInvalidUsernameMessage : AgendaEvent
-    object ShowInvalidEmailMessage : AgendaEvent
-    object ShowInvalidPasswordMessage : AgendaEvent
-    object ShowInvalidConfirmPasswordMessage : AgendaEvent
 
     data class Register(
             val username: String,
@@ -37,6 +25,11 @@ sealed interface AgendaEvent {
     data class RegisterSuccess(val message: UiText) : AgendaEvent
     data class RegisterError(val message: UiText) : AgendaEvent
 
-    object EmailAlreadyExists : AgendaEvent
     data class UnknownError(val message: UiText) : AgendaEvent
+
+
+
+    object ToggleLogoutDropdown : AgendaEvent
+    object Logout : AgendaEvent
+    data class SetIsLoaded(val isLoaded: Boolean) : AgendaEvent
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -181,19 +181,15 @@ fun AgendaScreenContent(
                         drawCircle(
                             color = acronymColor, //Color.Black,
                             radius = this.size.maxDimension * .7f
-                        )
-                    }
+                    )}
                     .clickable {
                         onAction(AgendaEvent.ToggleLogoutDropdown)
                     }
                     .onGloballyPositioned { coordinates ->
-                        // This value is used to assign to
-                        // the DropDown the same width
                         logoutButtonSize = coordinates.size.toSize()
                         logoutButtonOffset = coordinates.localToRoot(
                             Offset.Zero
-                        )
-                    }
+                    )}
             )
 
         }
@@ -343,7 +339,7 @@ fun AgendaScreenPreview() {
     apiLevel = 28,
     widthDp = 350,
 )
-fun AgendScreenPreview_NightMode_NO() {
+fun AgendaScreenPreview_NightMode_NO() {
     AgendaScreenPreview()
 }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -38,6 +38,7 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import com.realityexpander.tasky.MainActivity
+import com.realityexpander.tasky.agenda_feature.presentation.common.util.getUserAcronym
 import com.realityexpander.tasky.auth_feature.domain.AuthInfo
 import com.realityexpander.tasky.core.presentation.common.modifiers.DP
 import com.realityexpander.tasky.core.presentation.common.modifiers.extraSmallHeight
@@ -125,49 +126,6 @@ fun AgendaScreenContent(
 
         onDispose {
             view.viewTreeObserver.removeOnGlobalLayoutListener(listener)
-        }
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-    ) {
-        // • User logout dropdown
-        DropdownMenu(
-            expanded = state.isLogoutDropdownShowing,
-            onDismissRequest = { onAction(AgendaEvent.ToggleLogoutDropdown) },
-            offset = DpOffset(
-                x = logoutButtonOffset.x.dp - logoutButtonSize.width.dp * 3f,
-                y = 0.dp
-            ),
-            modifier = Modifier
-                .width(with(LocalDensity.current) {
-                    (logoutButtonSize.width * 6f).toDp()
-                })
-                .background(color = MaterialTheme.colors.onSurface)
-        ) {
-            DropdownMenuItem(
-                onClick = {
-                    onAction(AgendaEvent.ToggleLogoutDropdown)
-                    onAction(AgendaEvent.Logout)
-                }) {
-                Text(
-                    text = "Logout",
-                    style = MaterialTheme.typography.body1,
-                    color = MaterialTheme.colors.surface,
-                    textAlign = TextAlign.Start,
-                    modifier = Modifier.weight(1f)
-                )
-                Icon(
-                    imageVector = Icons.Filled.Logout,
-                    contentDescription = "Logout",
-                    tint = MaterialTheme.colors.surface,
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .padding(DP.tiny)
-                )
-            }
         }
     }
 
@@ -306,21 +264,49 @@ fun AgendaScreenContent(
 //            }
         }
     }
-}
 
-fun getUserAcronym(username: String): String {
-    if(username.isBlank()) return "??"
-    if(username.length<2) return username.uppercase()
-
-    println("username: $username")
-
-    val words = username.split(" ")
-    println("words: $words, size: ${words.size}")
-    if (words.size > 1) {
-        return (words[0].substring(0, 1) + words[1].substring(0, 1)).uppercase()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+    ) {
+        // • User logout dropdown
+        DropdownMenu(
+            expanded = state.isLogoutDropdownShowing,
+            onDismissRequest = { onAction(AgendaEvent.ToggleLogoutDropdown) },
+            offset = DpOffset(
+                x = logoutButtonOffset.x.dp - logoutButtonSize.width.dp * 3f,
+                y = 0.dp
+            ),
+            modifier = Modifier
+                .width(with(LocalDensity.current) {
+                    (logoutButtonSize.width * 6f).toDp()
+                })
+                .background(color = MaterialTheme.colors.onSurface)
+        ) {
+            DropdownMenuItem(
+                onClick = {
+                    onAction(AgendaEvent.ToggleLogoutDropdown)
+                    onAction(AgendaEvent.Logout)
+                }) {
+                Text(
+                    text = "Logout",
+                    style = MaterialTheme.typography.body1,
+                    color = MaterialTheme.colors.surface,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    imageVector = Icons.Filled.Logout,
+                    contentDescription = "Logout",
+                    tint = MaterialTheme.colors.surface,
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .padding(DP.tiny)
+                )
+            }
+        }
     }
-
-    return username.substring(0, 2).uppercase()
 }
 
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -1,33 +1,43 @@
 package com.realityexpander.tasky.agenda_feature.presentation.agenda_screen
 
+import android.content.res.Configuration
 import android.view.ViewTreeObserver
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
 import com.realityexpander.tasky.MainActivity
-import com.realityexpander.tasky.R
-import com.realityexpander.tasky.core.presentation.common.modifiers.largeHeight
+import com.realityexpander.tasky.auth_feature.domain.AuthInfo
+import com.realityexpander.tasky.core.presentation.common.modifiers.DP
+import com.realityexpander.tasky.core.presentation.common.modifiers.extraSmallHeight
 import com.realityexpander.tasky.core.presentation.common.modifiers.mediumHeight
 import com.realityexpander.tasky.core.presentation.common.modifiers.taskyScreenTopCorners
+import com.realityexpander.tasky.core.presentation.theme.TaskyTheme
 import com.realityexpander.tasky.destinations.LoginScreenDestination
 
 @Composable
@@ -77,9 +87,10 @@ fun AgendaScreenContent(
         }
     }
 
-    // Guard against invalid authentication state
+    // Guard against invalid authentication state OR perform logout
     SideEffect {
         if (state.isLoaded && state.authInfo == null) {
+            onAction(AgendaEvent.SetIsLoaded(false))
             navigateToLogin()
         }
     }
@@ -109,16 +120,65 @@ fun AgendaScreenContent(
             .fillMaxSize()
             .background(color = MaterialTheme.colors.onSurface)
     ) col1@ {
-        Spacer(modifier = Modifier.largeHeight())
-        Text(
-            text = stringResource(R.string.agenda_title),
-            style = MaterialTheme.typography.h5,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colors.surface,
-            modifier = Modifier
-                .align(alignment = Alignment.CenterHorizontally)
-        )
         Spacer(modifier = Modifier.mediumHeight())
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = DP.small, end = DP.small)
+        ) {
+            Row(
+                modifier = Modifier
+                    .alignByBaseline()
+            ) {
+                Text(
+                    text = "MARCH", //stringResource(R.string.agenda_title),
+                    style = MaterialTheme.typography.h3,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colors.surface,
+                    modifier = Modifier
+                        .wrapContentWidth(Alignment.Start)
+                        .alignByBaseline()
+                        .align(Alignment.CenterVertically)
+                        .clickable {
+                            onAction(AgendaEvent.ToggleLogoutDropdown)
+                        }
+                )
+                Icon(
+                    imageVector = if (state.isLogoutDropdownShowing)
+                        Icons.Filled.KeyboardArrowUp
+                    else
+                        Icons.Filled.KeyboardArrowDown,
+                    tint = MaterialTheme.colors.surface,
+                    contentDescription = "Logout dropdown",
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .clickable {
+                            onAction(AgendaEvent.ToggleLogoutDropdown)
+                        }
+                )
+            }
+            Text(
+                text = "CA", //stringResource(R.string.agenda_title),
+                style = MaterialTheme.typography.h4,
+                textAlign = TextAlign.End,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier
+                    .alignByBaseline()
+                    .align(Alignment.CenterVertically)
+                    .weight(1f)
+                    .wrapContentWidth(Alignment.End)
+                    .padding(DP.tiny)
+                    .drawBehind {
+                        drawCircle(
+                            color = Color.Black,
+                            radius = this.size.maxDimension*.7f
+                        )
+                    }
+            )
+
+        }
+        Spacer(modifier = Modifier.extraSmallHeight())
 
         Column(
             modifier = Modifier
@@ -132,121 +192,6 @@ fun AgendaScreenContent(
                 "Hello, " + (state.authInfo?.username ?: "No username"),
                 color = MaterialTheme.colors.onSurface
             )
-//
-//            // • USERNAME
-//            NameField(
-//                value = state.username,
-//                label = null,
-//                isError = state.isInvalidUsername,
-//                onValueChange = {
-//                    onAction(RegisterEvent.UpdateUsername(it))
-//                }
-//            )
-//            if (state.isInvalidUsername && state.isShowInvalidUsernameMessage) {
-//                Text(text = stringResource(R.string.error_invalid_username), color = Color.Red)
-//            }
-//            Spacer(modifier = Modifier.smallHeight())
-//
-//            // • EMAIL
-//            EmailField(
-//                value = state.email,
-//                label = null,
-//                isError = state.isInvalidEmail,
-//                onValueChange = {
-//                    onAction(RegisterEvent.UpdateEmail(it))
-//                }
-//            )
-//            if (state.isInvalidEmail && state.isShowInvalidEmailMessage) {
-//                Text(text = stringResource(R.string.error_invalid_email), color = Color.Red)
-//            }
-//            Spacer(modifier = Modifier.smallHeight())
-//
-//            // • PASSWORD
-//            PasswordField(
-//                value = state.password,
-//                label = null,
-//                isError = state.isInvalidPassword,
-//                onValueChange = {
-//                    onAction(RegisterEvent.UpdatePassword(it))
-//                },
-//                isPasswordVisible = state.isPasswordVisible,
-//                clickTogglePasswordVisibility = {
-//                    onAction(RegisterEvent.SetIsPasswordVisible(!state.isPasswordVisible))
-//                },
-//                imeAction = ImeAction.Next,
-//            )
-//            if (state.isInvalidPassword && state.isShowInvalidPasswordMessage) {
-//                Text(text = stringResource(R.string.error_invalid_password), color = Color.Red)
-//            }
-//            Spacer(modifier = Modifier.smallHeight())
-//
-//            // • CONFIRM PASSWORD
-//            PasswordField(
-//                label = null, //stringResource(R.string.register_label_confirm_password),
-//                placeholder = stringResource(R.string.register_placeholder_confirm_password),
-//                value = state.confirmPassword,
-//                isError = state.isInvalidConfirmPassword,
-//                onValueChange = {
-//                    onAction(RegisterEvent.UpdateConfirmPassword(it))
-//                },
-//                isPasswordVisible = state.isPasswordVisible,
-//                clickTogglePasswordVisibility = {
-//                    onAction(RegisterEvent.SetIsPasswordVisible(!state.isPasswordVisible))
-//                },
-//                imeAction = ImeAction.Done,
-//                doneAction = {
-//                    performRegister()
-//                },
-//            )
-//            if (state.isInvalidConfirmPassword && state.isShowInvalidConfirmPasswordMessage) {
-//                Text(
-//                    text = stringResource(R.string.error_invalid_confirm_password),
-//                    color = Color.Red
-//                )
-//                Spacer(modifier = Modifier.extraSmallHeight())
-//            }
-//            // • SHOW IF MATCHING PASSWORDS
-//            if (!state.isPasswordsMatch) {
-//                Text(
-//                    text = stringResource(R.string.register_error_passwords_do_not_match),
-//                    color = Color.Red
-//                )
-//                Spacer(modifier = Modifier.extraSmallHeight())
-//            }
-//            // • SHOW PASSWORD REQUIREMENTS
-//            if (state.isShowInvalidPasswordMessage || state.isShowInvalidConfirmPasswordMessage) {
-//                Text(
-//                    text = stringResource(R.string.register_password_requirements),
-//                    color = Color.Red
-//                )
-//                Spacer(modifier = Modifier.extraSmallHeight())
-//            }
-//            Spacer(modifier = Modifier.mediumHeight())
-//
-//            // • REGISTER BUTTON
-//            Button(
-//                onClick = {
-//                    performRegister()
-//                },
-//                enabled = !state.isLoading,
-//                modifier = Modifier
-//                    .taskyWideButton(color = MaterialTheme.colors.primary)
-//                    .align(alignment = Alignment.CenterHorizontally)
-//            ) {
-//                Text(
-//                    text = stringResource(R.string.register_button),
-//                    fontSize = MaterialTheme.typography.button.fontSize,
-//                )
-//                if (state.isLoading) {
-//                    CircularProgressIndicator(
-//                        modifier = Modifier
-//                            .padding(start = DP.small)
-//                            .size(16.dp)
-//                            .align(alignment = Alignment.CenterVertically)
-//                    )
-//                }
-//            }
-//
 //            // STATUS //////////////////////////////////////////
 //
 //            state.errorMessage.getOrNull?.let { errorMessage ->
@@ -257,17 +202,11 @@ fun AgendaScreenContent(
 //                )
 //                Spacer(modifier = Modifier.extraSmallHeight())
 //            }
-//            if (state.isLoggedIn) {
-//                Spacer(modifier = Modifier.smallHeight())
-//                Text(text = stringResource(R.string.register_registered))
-//                Spacer(modifier = Modifier.extraSmallHeight())
-//            }
 //            state.statusMessage.getOrNull?.let { message ->
 //                Spacer(modifier = Modifier.extraSmallHeight())
 //                Text(text = message)
 //                Spacer(modifier = Modifier.extraSmallHeight())
 //            }
-//
 //
 //            Box(
 //                modifier = Modifier
@@ -320,6 +259,28 @@ fun AgendaScreenContent(
 //            })
 //    )
 
+@Composable
+@Preview(
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    showSystemUi = false,
+    name = "Agenda Screen Dark",
+    apiLevel = 28
+)
+fun AgendaScreenPreview() {
+    TaskyTheme {
+        AgendaScreenContent(
+            state = AgendaState(
+                authInfo = AuthInfo(
+                    username = "username",
+                ),
+                isLoaded = true,
+            ),
+            onAction = {},
+            navigator = EmptyDestinationsNavigator,
+        )
+    }
+}
 
 //@Composable
 //@Preview(

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -89,6 +89,7 @@ fun AgendaScreenContent(
             LoginScreenDestination(
                 username = state.username,
                 email = state.email,
+                password = null,
             )
         ) {
             popUpTo(LoginScreenDestination.route) {

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -246,6 +246,17 @@ fun AgendaScreenContent(
     }
 }
 
+fun getUserAcronym(username: String): String {
+    if(username.isBlank()) return ""
+
+    val words = username.split(" ")
+    if (words.size > 1) {
+        return words[0].substring(0, 1) + words[1].substring(0, 1)
+    }
+
+    return username.substring(0, 2)
+}
+
 
 //    // • BACK TO SIGN IN BUTTON (alternate design)
 //    Text(

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -22,11 +22,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.core.view.ViewCompat
@@ -77,8 +79,8 @@ fun AgendaScreenContent(
     val focusManager = LocalFocusManager.current
     val context = LocalContext.current
 
-    var mTextFieldSize by remember { mutableStateOf(Size.Zero)}
-    var mTextFieldOffset by remember { mutableStateOf(Offset.Zero)}
+    var logoutButtonSize by remember { mutableStateOf(Size.Zero)}
+    var logoutButtonOffset by remember { mutableStateOf(Offset.Zero)}
 
     val acronymColor = Color(MaterialTheme.colors.surface.toArgb())
 
@@ -125,6 +127,49 @@ fun AgendaScreenContent(
         }
     }
 
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+    ) {
+        // • User logout dropdown
+        DropdownMenu(
+            expanded = state.isLogoutDropdownShowing,
+            onDismissRequest = { onAction(AgendaEvent.ToggleLogoutDropdown) },
+            offset = DpOffset(
+                x = logoutButtonOffset.x.dp - logoutButtonSize.width.dp * 3f,
+                y = 0.dp
+            ),
+            modifier = Modifier
+                .width(with(LocalDensity.current) {
+                    (logoutButtonSize.width * 6f).toDp()
+                })
+                .background(color = MaterialTheme.colors.onSurface)
+        ) {
+            DropdownMenuItem(
+                onClick = {
+                    onAction(AgendaEvent.ToggleLogoutDropdown)
+                    onAction(AgendaEvent.Logout)
+                }) {
+                Text(
+                    text = "Logout",
+                    style = MaterialTheme.typography.body1,
+                    color = MaterialTheme.colors.surface,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    imageVector = Icons.Filled.Logout,
+                    contentDescription = "Logout",
+                    tint = MaterialTheme.colors.surface,
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .padding(DP.tiny)
+                )
+            }
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -141,7 +186,7 @@ fun AgendaScreenContent(
                     .alignByBaseline()
             ) {
                 Text(
-                    text = "MARCH", //stringResource(R.string.agenda_title),
+                    text = "AUGUST", //stringResource(R.string.agenda_title),
                     style = MaterialTheme.typography.h4,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colors.surface,
@@ -159,9 +204,6 @@ fun AgendaScreenContent(
                     contentDescription = "Logout dropdown",
                     modifier = Modifier
                         .align(Alignment.CenterVertically)
-                        .clickable {
-                            onAction(AgendaEvent.ToggleLogoutDropdown)
-                        }
                 )
             }
             Text(
@@ -182,14 +224,17 @@ fun AgendaScreenContent(
                             radius = this.size.maxDimension * .7f
                         )
                     }
+                    .clickable {
+                        onAction(AgendaEvent.ToggleLogoutDropdown)
+                    }
                     .onGloballyPositioned { coordinates ->
                         // This value is used to assign to
                         // the DropDown the same width
-                        mTextFieldSize = coordinates.size.toSize()
-                        mTextFieldOffset = coordinates.localToRoot(
+                        logoutButtonSize = coordinates.size.toSize()
+                        logoutButtonOffset = coordinates.localToRoot(
                             Offset.Zero
                         )
-                    },
+                    }
             )
 
         }
@@ -207,7 +252,8 @@ fun AgendaScreenContent(
                 "Hello, " + (state.authInfo?.username ?: "No username"),
                 color = MaterialTheme.colors.onSurface
             )
-//            // STATUS //////////////////////////////////////////
+
+            ////// STATUS ///////
 //
 //            state.errorMessage.getOrNull?.let { errorMessage ->
 //                Spacer(modifier = Modifier.smallHeight())
@@ -257,56 +303,18 @@ fun AgendaScreenContent(
 //                    }
 //                }
 //            }
-
-            DropdownMenu(
-                expanded = true, //state.isLogoutDropdownShowing,
-                onDismissRequest = { onAction(AgendaEvent.ToggleLogoutDropdown) },
-                modifier = Modifier
-                    .width(250.dp) //mTextFieldSize.width.dp)
-                    .offset(
-                        x = 750.dp, //mTextFieldOffset.x.dp,
-                        y = 500.dp, //mTextFieldOffset.y.dp
-                    )
-                    .background(color = MaterialTheme.colors.surface)
-//                modifier = Modifier
-//                    .width(with(LocalDensity.current) {
-//                        200.dp //mTextFieldSize.width.toDp()
-//                    })
-//                    .offset(
-//                        x = with(LocalDensity.current) {
-//                            200.dp  //mTextFieldOffset.x.toDp()
-//                        },
-//                        y = with(LocalDensity.current) {
-//                            100.dp //mTextFieldOffset.y.toDp()
-//                        }
-//                    )
-            ) {
-                DropdownMenuItem(
-                    onClick = {
-                        onAction(AgendaEvent.ToggleLogoutDropdown)
-                    }) {
-                    Text(
-                        text = "Logout",
-                        style = MaterialTheme.typography.body1,
-                        //color = MaterialTheme.colors.onSurface,
-                        color = Color.White,
-                    )
-                    Icon(
-                        imageVector = Icons.Filled.Logout,
-                        contentDescription = "Logout",
-                        tint = Color.White,
-                    )
-                }
-            }
         }
-
     }
 }
 
 fun getUserAcronym(username: String): String {
-    if(username.isBlank()) return ""
+    if(username.isBlank()) return "??"
+    if(username.length<2) return username.uppercase()
+
+    println("username: $username")
 
     val words = username.split(" ")
+    println("words: $words, size: ${words.size}")
     if (words.size > 1) {
         return (words[0].substring(0, 1) + words[1].substring(0, 1)).uppercase()
     }
@@ -348,7 +356,7 @@ fun AgendaScreenPreview() {
     apiLevel = 28,
     widthDp = 350,
 )
-fun AgendacreenPreview_NightMode_NO() {
+fun AgendScreenPreview_NightMode_NO() {
     AgendaScreenPreview()
 }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaState.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaState.kt
@@ -6,10 +6,13 @@ import com.realityexpander.tasky.core.presentation.common.util.UiText
 data class AgendaState(
     val username: String = "",
     val email: String = "",
+    val authInfo: AuthInfo? = null,
 
     val isLoaded: Boolean = false,
+    val isLoading: Boolean = false,
 
     val errorMessage: UiText = UiText.None,
 
-    val authInfo: AuthInfo? = null
+    val isLogoutDropdownShowing: Boolean = false,
+
 )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
@@ -68,7 +68,7 @@ class AgendaViewModel @Inject constructor(
         }
     }
 
-    fun logout() {
+    private fun logout() {
         viewModelScope.launch {
             authRepository.clearAuthInfo()
             yield()

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/getUserAcronym.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/getUserAcronym.kt
@@ -1,0 +1,16 @@
+package com.realityexpander.tasky.agenda_feature.presentation.common.util
+
+fun getUserAcronym(username: String): String {
+    if(username.isBlank()) return "??"
+    if(username.length<2) return username.uppercase()
+
+    println("username: $username")
+
+    val words = username.split(" ")
+    println("words: $words, size: ${words.size}")
+    if (words.size > 1) {
+        return (words[0].substring(0, 1) + words[1].substring(0, 1)).uppercase()
+    }
+
+    return username.substring(0, 2).uppercase()
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/getUserAcronym.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/getUserAcronym.kt
@@ -4,13 +4,23 @@ fun getUserAcronym(username: String): String {
     if(username.isBlank()) return "??"
     if(username.length<2) return username.uppercase()
 
-    println("username: $username")
-
     val words = username.split(" ")
-    println("words: $words, size: ${words.size}")
     if (words.size > 1) {
-        return (words[0].substring(0, 1) + words[1].substring(0, 1)).uppercase()
+        return (words.first().substring(0, 1) + words.last().substring(0, 1)).uppercase()
     }
 
     return username.substring(0, 2).uppercase()
+}
+
+fun main() {
+    // test getUserAcronym
+    println(getUserAcronym("John Doe") == "JD")
+    println(getUserAcronym("John") == "JO")
+    println(getUserAcronym("J") == "J")
+    println(getUserAcronym("") == "??")
+    println(getUserAcronym("John Doe Smith") == "JS")
+    println(getUserAcronym("John Doe Smith Jr.") == "JJ")
+    println(getUserAcronym("John Doe Smith Jr. III") == "JI")
+    println(getUserAcronym("John Doe Smith Jr. III IV") == "JI")
+    println(getUserAcronym("John Doe Smith Jr. III IV V") == "JV")
 }

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/authApiImpls/AuthApiFakeImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/authApiImpls/AuthApiFakeImpl.kt
@@ -170,12 +170,13 @@ suspend fun main() {
 
     println()
 
+    val authTokenOnServer = user?.authToken
     authApiFakeImpl.clearAuthToken() // clear the AuthToken for the logged-in user
     println("AuthApiFakeImpl.authenticate() Logged out user has no authToken")
     println("   IAuthApi.authToken=null, token is NOT valid locally=" +
                 assert(!authApiFakeImpl.authenticate()))
     println("   user.authToken still valid on server=" +
-                assert(authApiFakeImpl.authenticate()))
+                assert(authApiFakeImpl.authenticateAuthToken(authTokenOnServer)))
 
     println()
 

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/login_screen/LoginScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/login_screen/LoginScreen.kt
@@ -147,7 +147,7 @@ fun LoginScreenContent(
         Spacer(modifier = Modifier.largeHeight())
         Text(
             text = stringResource(R.string.login_title),
-            style = MaterialTheme.typography.h5,
+            style = MaterialTheme.typography.h2,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colors.surface,
             modifier = Modifier

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
@@ -318,7 +318,6 @@ fun RegisterScreenContent(
                             modifier = Modifier
                                 .align(alignment = Alignment.CenterVertically)
                                 .size(DP.extraLarge)
-
                         )
                     }
                 }

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
@@ -69,6 +69,7 @@ fun RegisterScreen(
     )
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RegisterScreenContent(
     state: RegisterState,
@@ -302,24 +303,29 @@ fun RegisterScreenContent(
                         .background(color = MaterialTheme.colors.surface)
                         .align(alignment = Alignment.BottomStart)
                 ) {
-                    // • BACK TO SIGN IN BUTTON
-                    Button(
-                        onClick = {
-                            navigateToLogin()
-                        },
-                        modifier = Modifier
-                            .clip(shape = TaskyShapes.MediumButtonRoundedCorners)
-                            .align(alignment = Alignment.BottomStart)
-                            .width(DP.huge)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.ChevronLeft,
-                            contentDescription = stringResource(R.string.register_description_back),
+                    // • BACK TO LOGIN BUTTON
+                    CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) { // allows smaller touch-targets
+                        IconButton(
+                            onClick = {
+                                navigateToLogin()
+                            },
                             modifier = Modifier
-                                .align(alignment = Alignment.CenterVertically)
-                                .size(DP.extraLarge)
-                        )
-                    }
+                                .size(DP.XXLarge)
+                                .clip(shape = TaskyShapes.MediumButtonRoundedCorners)
+                                .background(color = MaterialTheme.colors.onSurface)
+                                .align(alignment = Alignment.BottomStart)
+                        ) {
+                                Icon(
+                                    tint = MaterialTheme.colors.surface,
+                                    imageVector = Icons.Filled.ChevronLeft,
+                                    contentDescription = stringResource(R.string.register_description_back),
+                                    modifier = Modifier
+                                        .align(alignment = Alignment.Center)
+                                        .size(DP.XXLarge)
+                                        .padding(start = 9.dp, end = 9.dp) // fine tunes the icon size (weird)
+                                )
+                            }
+                        }
                 }
             }
         }
@@ -327,7 +333,7 @@ fun RegisterScreenContent(
 }
 
 
-//    // • BACK TO SIGN IN BUTTON (alternate design)
+//    // • BACK TO LOG IN BUTTON (alternate design)
 //    Text(
 //        text = stringResource(R.string.register_already_a_member_sign_in),
 //        style = MaterialTheme.typography.body2,

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/register_screen/RegisterScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
@@ -40,6 +41,7 @@ import com.realityexpander.tasky.auth_feature.presentation.components.EmailField
 import com.realityexpander.tasky.auth_feature.presentation.components.NameField
 import com.realityexpander.tasky.auth_feature.presentation.components.PasswordField
 import com.realityexpander.tasky.core.presentation.common.modifiers.*
+import com.realityexpander.tasky.core.presentation.theme.TaskyShapes
 import com.realityexpander.tasky.core.presentation.theme.TaskyTheme
 import com.realityexpander.tasky.destinations.LoginScreenDestination
 
@@ -131,7 +133,7 @@ fun RegisterScreenContent(
         Spacer(modifier = Modifier.largeHeight())
         Text(
             text = stringResource(R.string.register_title),
-            style = MaterialTheme.typography.h5,
+            style = MaterialTheme.typography.h2,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colors.surface,
             modifier = Modifier
@@ -306,15 +308,17 @@ fun RegisterScreenContent(
                             navigateToLogin()
                         },
                         modifier = Modifier
+                            .clip(shape = TaskyShapes.MediumButtonRoundedCorners)
                             .align(alignment = Alignment.BottomStart)
-                            .taskyMediumButton(color = MaterialTheme.colors.primary)
+                            .width(DP.huge)
                     ) {
                         Icon(
                             imageVector = Icons.Filled.ChevronLeft,
                             contentDescription = stringResource(R.string.register_description_back),
                             modifier = Modifier
-                                .size(DP.large)
                                 .align(alignment = Alignment.CenterVertically)
+                                .size(DP.extraLarge)
+
                         )
                     }
                 }

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/splash_screen/MainActivityViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/splash_screen/MainActivityViewModel.kt
@@ -1,45 +1,45 @@
 package com.realityexpander.tasky.auth_feature.presentation.splash_screen
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.realityexpander.tasky.auth_feature.domain.AuthInfo
 import com.realityexpander.tasky.auth_feature.domain.IAuthRepository
-import com.realityexpander.tasky.core.presentation.common.UIConstants.SAVED_STATE_authInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val authRepository: IAuthRepository,
-    private val savedStateHandle: SavedStateHandle,
+//    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val authInfo: AuthInfo? =
-        savedStateHandle[SAVED_STATE_authInfo]
+//    private val authInfo: AuthInfo? =
+//        savedStateHandle[SAVED_STATE_authInfo]
 
     private val _splashState = MutableStateFlow(SplashState())
-    val splashState = _splashState.onEach { state ->
+    val splashState = _splashState.asStateFlow()
+//        .onEach { state ->
         // save state for process death
-        savedStateHandle[SAVED_STATE_authInfo] = state.authInfo
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SplashState())
+//        savedStateHandle[SAVED_STATE_authInfo] = state.authInfo
+//    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SplashState())
 
-    init {
-        viewModelScope.launch {
-            yield() // allow the splashState to be initialized
-
-            // restore state after process death  // -- is this needed for splash screen?
-            _splashState.update {
-                it.copy(
-                    authInfo = authInfo,
-                    isLoading = true,
-                )}
-            yield() // allow the splashState to be restored
-        }
-    }
+//    init {
+//        viewModelScope.launch {
+//            yield() // allow the splashState to be initialized
+//
+//            // restore state after process death  // -- is this needed for splash screen?
+//            _splashState.update {
+//                it.copy(
+//                    authInfo = authInfo,
+//                    isLoading = true,
+//                )}
+//            yield() // allow the splashState to be restored
+//        }
+//    }
 
     fun onSetAuthInfo(authInfo: AuthInfo?) {
         viewModelScope.launch {
@@ -47,7 +47,7 @@ class MainActivityViewModel @Inject constructor(
             // set the AuthInfo (& AuthToken) for this user
             authRepository.setAuthInfo(authInfo)
 
-            if (authInfo != null
+            if( authInfo != null
                 && authRepository.authenticate()
             ) {
                 // User is authenticated

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/splash_screen/MainActivityViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/presentation/splash_screen/MainActivityViewModel.kt
@@ -17,29 +17,8 @@ class MainActivityViewModel @Inject constructor(
 //    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-//    private val authInfo: AuthInfo? =
-//        savedStateHandle[SAVED_STATE_authInfo]
-
     private val _splashState = MutableStateFlow(SplashState())
     val splashState = _splashState.asStateFlow()
-//        .onEach { state ->
-        // save state for process death
-//        savedStateHandle[SAVED_STATE_authInfo] = state.authInfo
-//    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SplashState())
-
-//    init {
-//        viewModelScope.launch {
-//            yield() // allow the splashState to be initialized
-//
-//            // restore state after process death  // -- is this needed for splash screen?
-//            _splashState.update {
-//                it.copy(
-//                    authInfo = authInfo,
-//                    isLoading = true,
-//                )}
-//            yield() // allow the splashState to be restored
-//        }
-//    }
 
     fun onSetAuthInfo(authInfo: AuthInfo?) {
         viewModelScope.launch {

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettings.kt
@@ -16,7 +16,7 @@ suspend fun DataStore<AppSettings>.saveAuthInfo(authInfo: AuthInfo) {
     }
 }
 
-suspend fun DataStore<AppSettings>.setSettingsInitialized(firstTime: Boolean) {
+suspend fun DataStore<AppSettings>.saveSettingsInitialized(firstTime: Boolean) {
     updateData { appSettings ->
         appSettings.copy(isSettingsInitialized = firstTime)
     }

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettings.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AppSettings(
     val authInfo: AuthInfo? = null,
-    var isSettingsInitialized: Boolean = false  // allows us to check if the initial data is loaded
+    var isSettingsInitialized: Boolean = false  // allows us to check if the settings is loaded
 )
 
 suspend fun DataStore<AppSettings>.saveAuthInfo(authInfo: AuthInfo) {
@@ -21,4 +21,3 @@ suspend fun DataStore<AppSettings>.saveSettingsInitialized(firstTime: Boolean) {
         appSettings.copy(isSettingsInitialized = firstTime)
     }
 }
-

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettingsSerializer.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettingsSerializer.kt
@@ -1,6 +1,5 @@
 package com.realityexpander.tasky.core.data.settings
 
-import android.util.Log
 import androidx.datastore.core.Serializer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,7 +19,7 @@ object AppSettingsSerializer : Serializer<AppSettings> {
                 deserializer = AppSettings.serializer(),
                 string = input.readBytes().decodeToString()
             ).also {
-                Log.d("APP_SETTINGS_READ", it.toString())
+                // Log.d("APP_SETTINGS_READ", it.toString())
             }
         } catch (e: SerializationException) {
             e.printStackTrace()
@@ -36,7 +35,7 @@ object AppSettingsSerializer : Serializer<AppSettings> {
                     value = t
                 ).encodeToByteArray()
                     .also {
-                        Log.d("APP_SETTINGS_WRITE", t.toString())
+                        // Log.d("APP_SETTINGS_WRITE", t.toString())
                     }
             )
         }

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettingsSerializer.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/AppSettingsSerializer.kt
@@ -1,5 +1,6 @@
 package com.realityexpander.tasky.core.data.settings
 
+import android.util.Log
 import androidx.datastore.core.Serializer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -8,20 +9,35 @@ import kotlinx.serialization.json.Json
 import java.io.InputStream
 import java.io.OutputStream
 
-object AppSettingsSerializer : Serializer<AppSettings> {
+class AppSettingsSerializer(
+    private val encrypted: Boolean = true
+) : Serializer<AppSettings> {
 
     override val defaultValue: AppSettings
         get() = AppSettings()
 
+    private val cryptoManager: CryptoManager by lazy {
+        CryptoManager()
+    }
+
     override suspend fun readFrom(input: InputStream): AppSettings {
         return try {
+            val inputBytes = if(encrypted) {
+                cryptoManager.decrypt(input)
+            } else {
+                input.readBytes()
+            }
+
             Json.decodeFromString(
                 deserializer = AppSettings.serializer(),
-                string = input.readBytes().decodeToString()
+                string = inputBytes.decodeToString()
             ).also {
-                // Log.d("APP_SETTINGS_READ", it.toString())
+                if(!encrypted) Log.d("APP_SETTINGS_READ", it.toString())
             }
         } catch (e: SerializationException) {
+            e.printStackTrace()
+            defaultValue
+        } catch(e: Exception) {
             e.printStackTrace()
             defaultValue
         }
@@ -29,15 +45,25 @@ object AppSettingsSerializer : Serializer<AppSettings> {
 
     override suspend fun writeTo(t: AppSettings, output: OutputStream) {
         withContext(Dispatchers.IO) {
-            output.write(
-                Json.encodeToString(
-                    serializer = AppSettings.serializer(),
-                    value = t
-                ).encodeToByteArray()
-                    .also {
-                        // Log.d("APP_SETTINGS_WRITE", t.toString())
-                    }
-            )
+            try {
+                val outputBytes =
+                    Json.encodeToString(
+                        serializer = AppSettings.serializer(),
+                        value = t
+                    ).encodeToByteArray()
+
+                if (encrypted) {
+                    cryptoManager.encrypt(
+                        bytes = outputBytes,
+                        outputStream = output
+                    )
+                } else {
+                    output.write(outputBytes)
+                    Log.d("APP_SETTINGS_WRITE", t.toString())
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 }

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
@@ -89,6 +89,7 @@ class CryptoManager {
             val iv = ByteArray(ivSize)
             it.read(iv)
 
+            // Get the size of the encrypted data as an Int
             val encryptedBytesSizeHighOrderByte = it.read()
             val encryptedBytesSizeLowOrderByte = it.read()
             val encryptedBytesSize =

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
@@ -1,0 +1,122 @@
+package com.realityexpander.tasky.core.data.settings
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.annotation.RequiresApi
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+
+// Source video
+// https://www.youtube.com/watch?v=D_q07P1sfcc
+
+// Stack overflow issues
+// https://stackoverflow.com/questions/17234359/javax-crypto-illegalblocksizeexception-input-length-must-be-multiple-of-16-whe
+// https://stackoverflow.com/questions/57590740/problem-with-decryption-cipher-in-android-aes-ctr-nopadding
+// https://stackoverflow.com/questions/14371709/android-crittografy-cipher-decrypt-doesnt-work
+// https://security.stackexchange.com/questions/29993/aes-cbc-padding-when-the-message-length-is-a-multiple-of-the-block-size
+// https://stackoverflow.com/questions/33557244/aes-decryption-not-working-for-more-than-16-bytes
+// https://stackoverflow.com/questions/26950251/android-cipher-doesnt-decrypt-first-16-bytes-characters-of-encrypted-data
+// https://developer.android.com/topic/security/data
+//
+
+@RequiresApi(Build.VERSION_CODES.M)
+class CryptoManager {
+
+
+    private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+        load(null)
+    }
+
+    private val encryptCipher
+        get() = Cipher.getInstance(TRANSFORMATION).apply {
+            init(Cipher.ENCRYPT_MODE, getKey())
+        }
+
+    private fun getDecryptCipherForIv(iv: ByteArray): Cipher {
+        return Cipher.getInstance(TRANSFORMATION).apply {
+            init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))
+        }
+    }
+
+    private fun getKey(): SecretKey {
+        val existingKey =
+            keyStore.getEntry(KEYSTORE_ENTRY_NAME, null) as? KeyStore.SecretKeyEntry
+        return existingKey?.secretKey ?: createKey()
+    }
+
+    private fun createKey(): SecretKey {
+        return KeyGenerator.getInstance(ALGORITHM).apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                        KEYSTORE_ENTRY_NAME,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                    .setBlockModes(BLOCK_MODE)
+                    .setEncryptionPaddings(PADDING)
+                    .setUserAuthenticationRequired(false)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
+            )
+        }.generateKey()
+    }
+
+    fun encrypt(bytes: ByteArray, outputStream: OutputStream): ByteArray {
+        // Include the Initialization Vector (IV) at the start of the data to encrypt
+        val encryptedBytes = encryptCipher.doFinal(encryptCipher.iv + bytes)
+
+        outputStream.use {
+            it.write(encryptCipher.iv.size)
+            it.write(encryptCipher.iv)
+
+            // Save the size as Int - WHY DOES IT NOT JUST WRITE AN INT AS 2 BYTES? IN 2022? WTFFFFFFF??? IT ACCEPTS AN INT!!!!
+            it.write((encryptedBytes.size and 0xFF00) shr (8)) // mask to get high order byte of Int, write as byte
+            it.write(encryptedBytes.size and 0x00FF) // mask to get low order byte of Int, write as byte
+
+            it.write(encryptedBytes)
+        }
+        return encryptedBytes
+    }
+
+    fun decrypt(inputStream: InputStream): ByteArray {
+        return inputStream.use {
+            val ivSize = it.read()
+            val iv = ByteArray(ivSize)
+            it.read(iv)
+
+            val encryptedBytesSizeHighOrderByte = it.read()
+            val encryptedBytesSizeLowOrderByte = it.read()
+            val encryptedBytesSize =
+                (encryptedBytesSizeHighOrderByte shl (8)) or // rebuild the Int (why are we still doing this in 2022???)
+                (encryptedBytesSizeLowOrderByte)
+
+            val encryptedBytes = ByteArray(encryptedBytesSize)
+            it.read(encryptedBytes)
+
+            val decipheredByteArray = getDecryptCipherForIv(iv)
+                .doFinal(encryptedBytes)
+
+            // Strip the Initialization Vector (usually first 16 bytes) to get the actual unencrypted data
+            decipheredByteArray
+                .toList()
+                .subList(ivSize, decipheredByteArray.size) // skip the IV
+                .toByteArray()
+            //.decodeToString()  // for debugging
+            //.toByteArray()     // for debugging
+        }
+    }
+
+    companion object {
+        const val KEYSTORE_ENTRY_NAME = "secretTasky"
+        private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
+        private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
+        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7 // uses variable block size
+        private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
+    }
+
+}

--- a/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/settings/CryptoManager.kt
@@ -112,7 +112,7 @@ class CryptoManager {
     }
 
     companion object {
-        const val KEYSTORE_ENTRY_NAME = "secretTasky"
+        private const val KEYSTORE_ENTRY_NAME = "secretTasky"
         private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
         private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
         private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7 // uses variable block size

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
@@ -15,7 +15,7 @@ fun Modifier.taskyWideButton(color: Color = Color.White): Modifier =
     .clip(shape = TaskyShapes.WideButtonRoundedCorners)
     .background(color = color)
 
-fun Modifier.taskyMediumButton(color: Color = Color.White): Modifier =
+fun Modifier.taskySmallButton(color: Color = Color.White): Modifier =
     extraLargeHeight()
     .extraLargeWidth()
     .clip(shape = TaskyShapes.MediumButtonRoundedCorners)

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
@@ -1,10 +1,7 @@
 package com.realityexpander.tasky.core.presentation.common.modifiers
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -48,10 +45,10 @@ fun Modifier.largeHeight(): Modifier      = this.height(DP.large)
 fun Modifier.extraLargeHeight(): Modifier = this.height(DP.extraLarge)
 fun Modifier.hugeHeight(): Modifier       = this.height(DP.huge)
 
-fun Modifier.tinyWidth(): Modifier       = this.height(DP.tiny)
-fun Modifier.extraSmallWidth(): Modifier = this.height(DP.extraSmall)
-fun Modifier.smallWidth(): Modifier      = this.height(DP.small)
-fun Modifier.mediumWidth(): Modifier     = this.height(DP.medium)
-fun Modifier.largeWidth(): Modifier      = this.height(DP.large)
-fun Modifier.extraLargeWidth(): Modifier = this.height(DP.extraLarge)
-fun Modifier.hugeWidth(): Modifier       = this.height(DP.huge)
+fun Modifier.tinyWidth(): Modifier       = this.width(DP.tiny)
+fun Modifier.extraSmallWidth(): Modifier = this.width(DP.extraSmall)
+fun Modifier.smallWidth(): Modifier      = this.width(DP.small)
+fun Modifier.mediumWidth(): Modifier     = this.width(DP.medium)
+fun Modifier.largeWidth(): Modifier      = this.width(DP.large)
+fun Modifier.extraLargeWidth(): Modifier = this.width(DP.extraLarge)
+fun Modifier.hugeWidth(): Modifier       = this.width(DP.huge)

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/common/modifiers/UIElementModifiers.kt
@@ -34,6 +34,8 @@ object DP {
     val medium     = 24.dp
     val large      = 32.dp
     val extraLarge = 48.dp
+    val XXLarge    = 52.dp
+    val XXXLarge   = 56.dp
     val huge       = 64.dp
 }
 
@@ -43,6 +45,8 @@ fun Modifier.smallHeight(): Modifier      = this.height(DP.small)
 fun Modifier.mediumHeight(): Modifier     = this.height(DP.medium)
 fun Modifier.largeHeight(): Modifier      = this.height(DP.large)
 fun Modifier.extraLargeHeight(): Modifier = this.height(DP.extraLarge)
+fun Modifier.XXLargeHeight(): Modifier    = this.height(DP.XXLarge)
+fun Modifier.XXXLargeHeight(): Modifier   = this.height(DP.XXXLarge)
 fun Modifier.hugeHeight(): Modifier       = this.height(DP.huge)
 
 fun Modifier.tinyWidth(): Modifier       = this.width(DP.tiny)
@@ -51,4 +55,6 @@ fun Modifier.smallWidth(): Modifier      = this.width(DP.small)
 fun Modifier.mediumWidth(): Modifier     = this.width(DP.medium)
 fun Modifier.largeWidth(): Modifier      = this.width(DP.large)
 fun Modifier.extraLargeWidth(): Modifier = this.width(DP.extraLarge)
+fun Modifier.XXLargeWidth(): Modifier    = this.width(DP.XXLarge)
+fun Modifier.XXXLargeWidth(): Modifier   = this.width(DP.XXXLarge)
 fun Modifier.hugeWidth(): Modifier       = this.width(DP.huge)

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/theme/Color.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/theme/Color.kt
@@ -8,3 +8,4 @@ val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
 
 val TaskyPurple = Color(0xFF8E97FD)
+val TaskyLightBlue = Color(0xFFB7C6DE)

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/theme/Type.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/theme/Type.kt
@@ -19,32 +19,32 @@ val Typography = Typography(
     h1 = TextStyle(
         fontFamily = fonts,
         fontWeight = FontWeight.Bold,
-        fontSize = 96.sp
+        fontSize = 32.sp
     ),
     h2 = TextStyle(
         fontFamily = fonts,
         fontWeight = FontWeight.Bold,
-        fontSize = 60.sp
+        fontSize = 28.sp
     ),
     h3 = TextStyle(
         fontFamily = fonts,
         fontWeight = FontWeight.Bold,
-        fontSize = 48.sp
+        fontSize = 22.sp
     ),
     h4 = TextStyle(
         fontFamily = fonts,
         fontWeight = FontWeight.Bold,
-        fontSize = 34.sp
+        fontSize = 18.sp
     ),
     h5 = TextStyle(
         fontFamily = fonts,
-        fontWeight = FontWeight.Bold,
-        fontSize = 28.sp
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
     ),
     h6 = TextStyle(
         fontFamily = fonts,
-        fontWeight = FontWeight.Bold,
-        fontSize = 20.sp
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp
     ),
     subtitle1 = TextStyle(
         fontFamily = fonts,

--- a/app/src/main/java/com/realityexpander/tasky/di/AgendaRepositoryModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AgendaRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.realityexpander.tasky.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AgendaRepositoryModule {
+
+//    @Binds
+//    @Singleton
+//    @AgendaDaoFakeUsingBinds
+//    abstract fun bindAuthDaoFake(
+//        authDaoFakeImpl: AuthDaoFakeImpl  // <-- provides this instance...
+//    ): IAuthDao // <-- ... for this interface.
+
+}

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -66,11 +66,29 @@ object AppModule {
         val addHeadersInterceptor = Interceptor { chain ->
 
             runBlocking(Dispatchers.IO) {
-                val authToken = authDao.getAuthToken()
-                val request = chain.request().newBuilder()
+
+                val requestBuilder = chain.request().newBuilder()
                     .addHeader("x-api-key", API_KEY)
-                    .addHeader("Authorization",
-                        createAuthorizationHeader( authToken ?: "NULL_AUTH_TOKEN"))
+
+                // Check for a valid AuthToken already in the IAuthApi.
+                //   If not valid, attempt to get it from the AuthDao.
+                //   If it's valid, set it in the IAuthApi.
+                // This is to speed up the process of getting a valid AuthToken as
+                //   accessing the AuthDao can be slow.
+                if(IAuthApi.authToken == null) {
+                    val authToken = authDao.getAuthToken() // could take a while.
+                    if(authToken != null) {
+                        IAuthApi.authToken = authToken
+                    }
+                }
+
+                // If AuthToken is valid, add it to the request.
+                if(IAuthApi.authToken != null) {
+                    requestBuilder
+                        .addHeader("Authorization", createAuthorizationHeader(IAuthApi.authToken!!))
+                }
+
+                val request = requestBuilder
                     .build()
 
                 chain.proceed(request)

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -70,7 +70,7 @@ object AppModule {
                 val requestBuilder = chain.request().newBuilder()
                     .addHeader("x-api-key", API_KEY)
 
-                // Check for a valid AuthToken in the IAuthApi.
+                // Check for a valid AuthToken in the IAuthApi Companion object.
                 //   If not valid, attempt to get it from the AuthDao.
                 //   If valid, set it in the IAuthApi, for faster access.
                 if(IAuthApi.authToken == null) {

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -70,7 +70,7 @@ object AppModule {
                 val requestBuilder = chain.request().newBuilder()
                     .addHeader("x-api-key", API_KEY)
 
-                // Check for a valid AuthToken already in the IAuthApi.
+                // Check for a valid AuthToken in the IAuthApi.
                 //   If not valid, attempt to get it from the AuthDao.
                 //   If it's valid, set it in the IAuthApi.
                 // This is to speed up the process of getting a valid AuthToken as

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -106,6 +106,8 @@ object AppModule {
             .create()
     }
 
+    ////////// AUTHENTICATION REPOSITORY //////////
+
     @Provides
     @Singleton
     fun provideValidateEmail(): ValidateEmail = ValidateEmail()
@@ -221,6 +223,8 @@ object AppModule {
     fun provideAuthApiProd(
         taskyApi: TaskyApi,
     ): IAuthApi = AuthApiImpl(taskyApi)
+
+    ////////// AGENDA REPOSITORY //////////
 }
 
 @Qualifier

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -72,7 +72,7 @@ object AppModule {
 
                 // Check for a valid AuthToken in the IAuthApi Companion object.
                 //   If not valid, attempt to get it from the AuthDao.
-                //   If valid, set it in the IAuthApi, for faster access.
+                //   If valid, set it in the IAuthApi Companion object, for faster access.
                 if(IAuthApi.authToken == null) {
                     val authToken = authDao.getAuthToken() // could take a while.
                     if(authToken != null) {

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -72,9 +72,7 @@ object AppModule {
 
                 // Check for a valid AuthToken in the IAuthApi.
                 //   If not valid, attempt to get it from the AuthDao.
-                //   If it's valid, set it in the IAuthApi.
-                // This is to speed up the process of getting a valid AuthToken as
-                //   accessing the AuthDao can be slow.
+                //   If valid, set it in the IAuthApi, for faster access.
                 if(IAuthApi.authToken == null) {
                     val authToken = authDao.getAuthToken() // could take a while.
                     if(authToken != null) {

--- a/app/src/main/java/com/realityexpander/tasky/di/AuthRepositoryModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AuthRepositoryModule.kt
@@ -17,7 +17,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class RepositoryModule {
+abstract class AuthRepositoryModule {
 
     @Binds
     @Singleton

--- a/app/src/test/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/GetUserAcronymKtTest.kt
+++ b/app/src/test/java/com/realityexpander/tasky/agenda_feature/presentation/common/util/GetUserAcronymKtTest.kt
@@ -1,0 +1,62 @@
+package com.realityexpander.tasky.agenda_feature.presentation.common.util
+
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class GetUserAcronymKtTest {
+
+
+    @Test
+    fun `getUserAcronym() for First, Last name`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe") == "JD")
+    }
+
+    @Test
+    fun `getUserAcronym() for First name`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John") == "JO")
+    }
+
+    @Test
+    fun `getUserAcronym() for single letter`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("J") == "J")
+    }
+
+    @Test
+    fun `getUserAcronym() for empty string`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("") == "??")
+    }
+
+    @Test
+    fun `getUserAcronym() for First, Last, Middle name`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe Smith") == "JS")
+    }
+
+    @Test
+    fun `getUserAcronym() for First, Last, Middle name with Jr`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe Smith Jr.") == "JJ")
+    }
+
+    @Test
+    fun `getUserAcronym() for First, Last, Middle name with Jr and III`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe Smith Jr. III") == "JI")
+    }
+
+    @Test
+    fun `getUserAcronym() for First, Last, Middle name with Jr, III, IV`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe Smith Jr. III IV") == "JI")
+    }
+
+    @Test
+    fun `getUserAcronym() for First, Last, Middle name with Jr, III, IV, V`() {
+        // ARRANGE / ACT / ASSERT
+        assertTrue(getUserAcronym("John Doe Smith Jr. III IV V") == "JV")
+    }
+}

--- a/app/src/test/java/com/realityexpander/tasky/auth_feature/data/repository/remote/authApiImpls/AuthApiFakeImplTest.kt
+++ b/app/src/test/java/com/realityexpander/tasky/auth_feature/data/repository/remote/authApiImpls/AuthApiFakeImplTest.kt
@@ -106,7 +106,7 @@ class AuthApiFakeImplTest {
         // ACT
         runTest {
             val authInfoDTO = authApiFakeImpl.login(email, password)
-            val authenticated = authApiFakeImpl.authenticate(authInfoDTO?.authToken)
+            val authenticated = authApiFakeImpl.authenticate()
 
             // ASSERT
             assertTrue(authenticated)
@@ -123,7 +123,7 @@ class AuthApiFakeImplTest {
         // ACT
         runTest {
             val authInfoDTO: AuthInfo? = null
-            val authenticated = authApiFakeImpl.authenticate(authInfoDTO?.authToken)
+            val authenticated = authApiFakeImpl.authenticate()
 
             // ASSERT
             assertFalse(authenticated)


### PR DESCRIPTION
I am working hard to make these smaller!

- Add logout button
- Add header UI for Agenda screen (Date Picker placeholder, User Acronym)
- Add helper functions for UI
- Fixed some UI hiccups on the Login and Register screens
- Adjusted the Typography
- Added 2 more units to the size modifiers

## Question 1:
Do we need to save process death on splash screen?

## Question 2:
Which is the recommended way to add the Authorization Header to the retrofit instance?
I have 2 approaches as options, one gets the AuthToken from the AuthDao but requires that dependency. The other gets the AuthToken from the IAuthApi interface companion object.

```
// .../di/AppModule.kt
@Provides
@Singleton
fun provideTaskyApi(
    converterFactory: Converter.Factory,
    @AuthDaoProdUsingBinds authDao: IAuthDao, // for Option 1 only
): TaskyApi {
    val addHeadersInterceptor = Interceptor { chain ->

        // Option 1 - uses the `AuthDao` to get the `AuthToken` from the `DataStore`.
        //          - The `AuthDao` must be used as a dependency in this option.
        //          - Must use a `runBlocking` due to the `authDao.getAuthToken()` being a suspend function.
        runBlocking(Dispatchers.IO) {
            val authToken = authDao.getAuthToken() // <-- gets AuthToken from the AuthDaoImpl
            val request = chain.request().newBuilder()
                .addHeader("x-api-key", API_KEY)
                .addHeader(
                    "Authorization", createAuthorizationHeader(authToken ?: "NULL_AUTH_TOKEN")
                )
                .build()

            chain.proceed(request)
        }

        // Option 2 - uses the `AuthToken` stored in the `companion object` of the `IAuthApi` interface.
        //          - no need for the `AuthDao` to be a dependency of this object.
        //          - no need for the `runBlocking` since the `IAuthApi.authorizationHeader` is a simple string. (Faster access?)
        val request = chain.request().newBuilder()
            .addHeader("x-api-key", API_KEY)
            .addHeader("Authorization", IAuthApi.authorizationHeader ?: "NULL_AUTH_TOKEN") // <-- direct access here
            .build()
        chain.proceed(request)
    }

    // ... rest of the function
}
```
