### PR TITLE
0018 add photo chooser to event screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,6 +174,9 @@ dependencies {
     implementation "io.github.vanpra.compose-material-dialogs:datetime:$compose_material_dialogs_datetime_version"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.6'  // for LocalDateTime core library for java
 
+    // Image loading
+    implementation "io.coil-kt:coil-compose:2.2.1"
+
     // For testing
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/androidTest/java/com/realityexpander/tasky/EventDaoTest.kt
+++ b/app/src/androidTest/java/com/realityexpander/tasky/EventDaoTest.kt
@@ -6,7 +6,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.realityexpander.tasky.agenda_feature.data.repositories.TaskyDatabase
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.AttendeeEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.EventEntity
-import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoRemoteEntity
+import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.eventDao.IEventDao
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -65,7 +65,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = emptyList(),
             isDeleted = false,
@@ -110,7 +110,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -158,7 +158,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -204,7 +204,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -231,7 +231,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -278,7 +278,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -305,7 +305,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -358,7 +358,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -385,7 +385,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -437,7 +437,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -464,7 +464,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -523,7 +523,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -550,7 +550,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -577,7 +577,7 @@ open class EventDaoTest {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,

--- a/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/MainActivity.kt
@@ -47,8 +47,8 @@ class MainActivity : ComponentActivity() {
         if (false) {
             waitForDebugger() // leave for testing process death
         }
-
         super.onCreate(savedInstanceState)
+
 
         // Show AddEventScreen - temporary for UI work
         if (true) {

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
@@ -3,6 +3,7 @@ package com.realityexpander.tasky.agenda_feature.data.common.convertersDTOEntity
 import com.google.gson.GsonBuilder
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.EventEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.DTOs.EventDTO
+import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.DTOs.PhotoDTO
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.agenda_feature.domain.Attendee
 import com.realityexpander.tasky.agenda_feature.domain.Photo
@@ -89,7 +90,9 @@ fun AgendaItem.Event.toEventDTOCreate(): EventDTO.Create {
         to = to.toUtcMillis(),
         remindAt = remindAt.toUtcMillis(),
         attendeeIds = attendees.map { it.id },
-        photos = photosToUpload.map { it.toDTO() },
+        photos = photos
+            .filterIsInstance<Photo.Local>()        // only upload Local photos
+            .map { it.toDTO() },
     )
 }
 
@@ -109,7 +112,7 @@ fun AgendaItem.Event.toEventDTOUpdate(): EventDTO.Update {
 }
 
 // from Domain to EventDTO.Response (also converts local ZonedDateTime to UTC time millis)
-//   Note: this is used for fake implementations internally. It is not used in the normal app.
+//   Note: this is used for fake implementations internally. It is *NOT* used in the normal app.
 fun AgendaItem.Event.toEventDTOResponse(): EventDTO.Response {
     return EventDTO.Response(
         id = id,
@@ -119,9 +122,10 @@ fun AgendaItem.Event.toEventDTOResponse(): EventDTO.Response {
         to = to.toUtcMillis(),
         remindAt = remindAt.toUtcMillis(),
         isGoing = isGoing ?: false,
-        photos = photos.map {
-                    it.toDTO()
-                },
+        photos = photos
+            .map { it.toDTO() }
+            .filterIsInstance<PhotoDTO.Remote>()        // ensure only respond with Remote photos
+        ,
         attendees = attendees.map { it.toDTO() },
         isUserEventCreator = isUserEventCreator ?: false,
         host = host ?: "",

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/PhotoConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/PhotoConverters.kt
@@ -1,17 +1,23 @@
 package com.realityexpander.tasky.agenda_feature.data.common.convertersDTOEntityDomain
 
-import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoRemoteEntity
+import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.DTOs.PhotoDTO
 import com.realityexpander.tasky.agenda_feature.domain.Photo
 
 // From Entity to Domain
-fun PhotoRemoteEntity.toDomain() =
-    Photo.Remote(
-        id = id,
-        url = url,
-    )
+fun PhotoEntity.toDomain() =
+    if(uri==null)
+        Photo.Remote(
+            id = id,
+            url = url ?: throw IllegalStateException("PhotoEntity with null Uri must have non-null Url"),
+        )
+    else
+        Photo.Local(
+            id = id,
+            uri = uri,
+        )
 
-// From DTO to Domain
+// From DTO to Domain (only allows Remote bc Local is not sent from server)
 fun PhotoDTO.Remote.toDomain() =
     Photo.Remote(
         id = id,
@@ -19,21 +25,36 @@ fun PhotoDTO.Remote.toDomain() =
     )
 
 // From Domain to Entity
-fun Photo.Remote.toEntity() =
-    PhotoRemoteEntity(
-        id = id,
-        url = url,
-    )
+fun Photo.toEntity() =
+    when(this) {
+        is Photo.Remote ->
+            PhotoEntity(
+                id = id,
+                url = url,
+            )
+        is Photo.Local ->
+            PhotoEntity(
+                id = id,
+                uri = uri,
+            )
+    }
 
 // From Domain to DTO
-fun Photo.Remote.toDTO() =
-    PhotoDTO.Remote(
-        id = id,
-        url = url,
-    )
+fun Photo.toDTO() =
+    when(this) {
+        is Photo.Remote ->
+            PhotoDTO.Remote(
+                id = id,
+                url = url,
+            )
+        is Photo.Local ->
+            PhotoDTO.Local(
+                id = id,
+                uri = uri,
+            )
+    }
 
-// From Domain to DTO
-// Note: This is used for local photos that are about to uploaded to the server. // todo implement photo uploading
+// From Domain to PhotoDTO.Local
 fun Photo.Local.toDTO() =
     PhotoDTO.Local(
         id = id,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/serializers/UriSerializer.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/serializers/UriSerializer.kt
@@ -1,0 +1,38 @@
+package com.realityexpander.tasky.agenda_feature.data.common.serializers
+
+import android.net.Uri
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializer(forClass = Uri::class)
+object UriSerializer : KSerializer<Uri> {
+    override val descriptor = PrimitiveSerialDescriptor("Uri", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Uri {
+        return Uri.parse(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: Uri) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+// Local Test
+fun main() {
+    val uri = Uri.parse("https://www.google.com")
+    val uriStr = uri.toString()
+    val uri2 = Uri.parse(uriStr)
+
+    println("uri: $uri")
+    println("uriStr: $uriStr")
+    println("uri2: $uri2")
+
+    println()
+    println("uri == uri2: ${uri2 == uri}")
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/PhotoListTypeConverter.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/PhotoListTypeConverter.kt
@@ -1,21 +1,22 @@
 package com.realityexpander.tasky.agenda_feature.data.common.typeConverters
 
+import android.net.Uri
 import androidx.room.TypeConverter
-import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoRemoteEntity
+import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoEntity
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class PhotoListTypeConverter {
     @TypeConverter
-    fun fromPhotoList(value: List<PhotoRemoteEntity>?): String? {
+    fun fromPhotoList(value: List<PhotoEntity>?): String? {
         return value?.let {
             Json.encodeToString(it)
         }
     }
 
     @TypeConverter
-    fun toPhotoList(value: String?): List<PhotoRemoteEntity>? {
+    fun toPhotoList(value: String?): List<PhotoEntity>? {
         return value?.let {
             Json.decodeFromString(it)
         }
@@ -28,17 +29,20 @@ fun main() {
     val photoListConverter = PhotoListTypeConverter()
 
     val photoList = listOf(
-        PhotoRemoteEntity(
+        PhotoEntity(
             id = "1",
             url = "1",
+            uri = Uri.EMPTY
         ),
-        PhotoRemoteEntity(
+        PhotoEntity(
             id = "2",
             url = "2",
+            uri = Uri.EMPTY
         ),
-        PhotoRemoteEntity(
+        PhotoEntity(
             id = "3",
             url = "3",
+            uri = Uri.EMPTY
         ),
     )
     val photoListStr = photoListConverter.fromPhotoList(photoList)

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/UriTypeConverter.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/UriTypeConverter.kt
@@ -1,0 +1,28 @@
+package com.realityexpander.tasky.agenda_feature.data.common.typeConverters
+
+import android.net.Uri
+import androidx.room.TypeConverter
+
+class UriTypeConverter {
+    @TypeConverter
+    fun fromUri(uri: Uri): String = uri.toString()
+
+    @TypeConverter
+    fun toUri(uriStr: String): Uri = Uri.parse(uriStr)
+}
+
+// local test
+fun main() {
+    val uriConverter = UriTypeConverter()
+
+    val uri = Uri.parse("https://www.google.com")
+    val uriStr = uriConverter.fromUri(uri)
+    val uri2 = uriConverter.toUri(uriStr)
+
+    println("uri: $uri")
+    println("uriStr: $uriStr")
+    println("uri2: $uri2")
+
+    println()
+    println("uri == uri2: ${uri2 == uri}")
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
@@ -22,7 +22,7 @@ data class EventEntity(
     val isGoing: Boolean? = null,
 
     val attendees: List<AttendeeEntity> = emptyList(),
-    val photos: List<PhotoRemoteEntity> = emptyList(),
+    val photos: List<PhotoEntity> = emptyList(),
 
     val deletedPhotoKeys: List<PhotoId> = emptyList(),
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/PhotoEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/PhotoEntity.kt
@@ -1,11 +1,11 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities
 
+import android.net.Uri
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
 import com.realityexpander.tasky.agenda_feature.common.util.UrlStr
-    import kotlinx.serialization.Serializable
 
-@Serializable
-data class PhotoRemoteEntity(
+data class PhotoEntity(
     val id: PhotoId,
-    val url: UrlStr    // url of the photo on server
+    val url: UrlStr? = null,    // url of the photo on server
+    val uri: Uri? = null        // path to the photo on device
 )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/eventDao/eventDaoImpls/EventDaoFakeImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/eventDao/eventDaoImpls/EventDaoFakeImpl.kt
@@ -2,7 +2,7 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.eventReposito
 
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.AttendeeEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.EventEntity
-import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoRemoteEntity
+import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.PhotoEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.eventDao.IEventDao
 import com.realityexpander.tasky.agenda_feature.common.util.EventId
 import kotlinx.coroutines.*
@@ -303,7 +303,7 @@ suspend fun runGetEventsForDayFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -335,7 +335,7 @@ suspend fun runGetEventsForDayFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -365,7 +365,7 @@ suspend fun runGetEventsForDayFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -395,7 +395,7 @@ suspend fun runGetEventsForDayFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -436,7 +436,7 @@ suspend fun runGeneralDBFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -468,7 +468,7 @@ suspend fun runGeneralDBFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -498,7 +498,7 @@ suspend fun runGeneralDBFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -530,7 +530,7 @@ suspend fun runGeneralDBFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,
@@ -564,7 +564,7 @@ suspend fun runGeneralDBFlowTest(dao: IEventDao) {
                 ),
             ),
             photos = listOf(
-                PhotoRemoteEntity("1", "https://www.google.com")
+                PhotoEntity("1", "https://www.google.com")
             ),
             deletedPhotoKeys = listOf(),
             isDeleted = false,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -73,6 +73,6 @@ abstract class EventDTO {
         val attendees: List<AttendeeDTO> = emptyList(),
 
         // Note: Returns complete Photo objects (not Ids)
-        val photos: List<PhotoDTO.Remote> = emptyList(),
+        val photos: List<PhotoDTO.Remote> = emptyList(),  // NOTE: Only Remote photos are returned
     ) : EventDTO()
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/PhotoDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/PhotoDTO.kt
@@ -17,7 +17,7 @@ sealed interface PhotoDTO {
         val url: UrlStr,      // url of the photo on server
     ) : PhotoDTO
 
-    data class Local(
+    data class Local(         // Only used for uploading. NOT sent from/to server.
         val id: PhotoId,
         val uri: Uri,         // path to the photo on device
     ) : PhotoDTO

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -26,10 +26,8 @@ abstract class AgendaItem {
 
         val attendees: List<Attendee> = emptyList(),
 
-        val photos: List<Photo.Remote> = emptyList(),
+        val photos: List<Photo> = emptyList(),
         val deletedPhotoKeys: List<PhotoId> = emptyList(),  // only used for EventDTO.Update
-
-        val photosToUpload: List<Photo.Local> = emptyList(),
 
         val isDeleted: Boolean = false,
     ) : AgendaItem(), Parcelable

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -120,11 +120,6 @@ fun EventPropertyEditors(
         }
         is EditMode.ChooseAddPhoto -> {
             // Reference: https://github.com/philipplackner/NewPhotoPickerAndroid13/blob/master/app/src/main/java/com/plcoding/newphotopickerandroid13/MainActivity.kt
-
-            var selectedImageUri by remember {
-                mutableStateOf<Uri?>(null)
-            }
-
             singlePhotoPickerLauncher.launch(
                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
             )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -139,7 +139,6 @@ fun EventPropertyEditors(
                 buttons = {
                     positiveButton(
                         text = stringResource(R.string.ok),
-                        disableDismiss = true,  // don't close the dialog automatically when OK button is tapped
                         textStyle = MaterialTheme.typography.button.copy(
                             if (state.isAttendeeEmailValid == true)
                                 MaterialTheme.colors.onSurface

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -129,7 +129,7 @@ fun EventPropertyEditors(
                 buttons = {
                     positiveButton(
                         text = stringResource(R.string.ok),
-                        disableDismiss = true,  // don't close the dialog automatically when the button is pressed
+                        disableDismiss = true,  // don't close the dialog automatically when OK button is tapped
                         textStyle = MaterialTheme.typography.button.copy(
                             if(state.isAttendeeEmailValid == true)
                                 MaterialTheme.colors.onSurface
@@ -141,7 +141,10 @@ fun EventPropertyEditors(
                             onAction(ValidateAttendeeEmailExistsThenAddAttendee(attendeeEmail))
                         }
                     }
-                    negativeButton(text = stringResource(R.string.cancel)) { /* handled by onCloseRequest */ }
+                    negativeButton(text = stringResource(R.string.cancel)) {
+                        addAttendeeDialogState.hide()
+                        onAction(CancelEditMode)
+                    }
                 },
                 onCloseRequest = {
                     addAttendeeDialogState.hide()

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -129,7 +129,7 @@ fun EventPropertyEditors(
                 buttons = {
                     positiveButton(
                         text = stringResource(R.string.ok),
-                        disableDismiss = true,
+                        disableDismiss = true,  // don't close the dialog automatically when the button is pressed
                         textStyle = MaterialTheme.typography.button.copy(
                             if(state.isAttendeeEmailValid == true)
                                 MaterialTheme.colors.onSurface
@@ -162,7 +162,7 @@ fun EventPropertyEditors(
 
                 OutlinedTextField(
                     value = attendeeEmail,
-                    onValueChange = {email ->
+                    onValueChange = { email ->
                         attendeeEmail = email
                         onAction(ClearErrorsForAddAttendeeDialog)
                         onAction(ValidateAttendeeEmail(email))

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -124,30 +124,10 @@ fun EventPropertyEditors(
             var selectedImageUri by remember {
                 mutableStateOf<Uri?>(null)
             }
-//            val singlePhotoPickerLauncher =
-//                rememberLauncherForActivityResult(
-//                    contract = ActivityResultContracts.PickVisualMedia(),
-//                    onResult = { uri ->
-//                        selectedImageUri = uri
-//
-//                        uri?.let {
-//                            onAction(
-//                                EditMode.AddPhoto(
-//                                    Photo.Local(
-//                                        id = UUID.randomUUID().toString(),
-//                                        uri = uri
-//                                    )
-//                                )
-//                            )
-//                        }
-//                    }
-//                )
 
             singlePhotoPickerLauncher.launch(
                 PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
             )
-
-
         }
         is EditMode.ConfirmRemovePhoto -> TODO()
         is EditMode.ChooseAddAttendee -> {

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -49,11 +49,7 @@ fun EventPropertyEditors(
             EditTextModal(
                 text = editMode.text,
                 title = editMode.dialogTitle.get,
-                editTextStyle =
-                if (editMode is EditMode.ChooseTitleText)
-                    MaterialTheme.typography.h2  // cant access from non-compose function, make a wrapper?
-                else
-                    MaterialTheme.typography.body1, // cant access from non-compose function, make a wrapper?
+                editTextStyle = (editMode as EditMode.EditTextStyle).editTextStyle,
                 onSave = {
                     onAction(EditMode.UpdateText(it))
                 },

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventEditors.kt
@@ -1,5 +1,9 @@
 package com.realityexpander.tasky.agenda_feature.presentation.event_screen
 
+import android.net.Uri
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -35,6 +39,7 @@ fun EventPropertyEditors(
     editMode: EditMode,
     state: EventScreenState,
     onAction: (EventScreenEvent) -> Unit,
+    singlePhotoPickerLauncher: ManagedActivityResultLauncher<PickVisualMediaRequest, Uri?>,
 ) {
     when (editMode) {
         is EditMode.ChooseTitleText,
@@ -113,14 +118,44 @@ fun EventPropertyEditors(
         }
         is EditMode.ChooseRemindAtDateTime -> { // handled in the RemindAt UI element, this is here to remove compiler warning
         }
-        is EditMode.ChooseAddPhoto -> TODO()
+        is EditMode.ChooseAddPhoto -> {
+            // Reference: https://github.com/philipplackner/NewPhotoPickerAndroid13/blob/master/app/src/main/java/com/plcoding/newphotopickerandroid13/MainActivity.kt
+
+            var selectedImageUri by remember {
+                mutableStateOf<Uri?>(null)
+            }
+//            val singlePhotoPickerLauncher =
+//                rememberLauncherForActivityResult(
+//                    contract = ActivityResultContracts.PickVisualMedia(),
+//                    onResult = { uri ->
+//                        selectedImageUri = uri
+//
+//                        uri?.let {
+//                            onAction(
+//                                EditMode.AddPhoto(
+//                                    Photo.Local(
+//                                        id = UUID.randomUUID().toString(),
+//                                        uri = uri
+//                                    )
+//                                )
+//                            )
+//                        }
+//                    }
+//                )
+
+            singlePhotoPickerLauncher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+            )
+
+
+        }
         is EditMode.ConfirmRemovePhoto -> TODO()
         is EditMode.ChooseAddAttendee -> {
             val addAttendeeDialogState = rememberMaterialDialogState()
             var attendeeEmail by remember { mutableStateOf("") }
 
             addAttendeeDialogState.show()
-            MaterialDialog (
+            MaterialDialog(
                 dialogState = addAttendeeDialogState,
                 properties = DialogProperties(
                     dismissOnBackPress = true,
@@ -131,13 +166,13 @@ fun EventPropertyEditors(
                         text = stringResource(R.string.ok),
                         disableDismiss = true,  // don't close the dialog automatically when OK button is tapped
                         textStyle = MaterialTheme.typography.button.copy(
-                            if(state.isAttendeeEmailValid == true)
+                            if (state.isAttendeeEmailValid == true)
                                 MaterialTheme.colors.onSurface
                             else
                                 MaterialTheme.colors.onSurface.copy(alpha = 0.3f)
                         )
                     ) {
-                        if(state.isAttendeeEmailValid == true) {
+                        if (state.isAttendeeEmailValid == true) {
                             onAction(ValidateAttendeeEmailExistsThenAddAttendee(attendeeEmail))
                         }
                     }
@@ -196,7 +231,8 @@ fun EventPropertyEditors(
                             }
                         }
                     },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
                         .padding(start = DP.small, end = DP.small)
                 )
                 Spacer(modifier = Modifier.smallHeight())
@@ -216,10 +252,10 @@ fun EventPropertyEditors(
         is EditMode.ConfirmRemoveAttendee -> {
             val attendee = editMode.attendee
             val deleteAttendeeDialogState = rememberMaterialDialogState()
-            onAction(SetIsEditable(true  )) // turn on edit mode when removing attendee
+            onAction(SetIsEditable(true)) // turn on edit mode when removing attendee
 
             deleteAttendeeDialogState.show()
-            MaterialDialog (
+            MaterialDialog(
                 dialogState = deleteAttendeeDialogState,
                 properties = DialogProperties(
                     dismissOnBackPress = true,
@@ -255,13 +291,15 @@ fun EventPropertyEditors(
                     text = attendee.fullName,
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.h4,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
                         .padding(start = DP.small, end = DP.small)
                 )
                 Text(
                     text = attendee.email,
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
                         .padding(start = DP.small, end = DP.small)
                 )
                 Spacer(modifier = Modifier.smallHeight())

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -373,7 +373,7 @@ fun AddEventScreenContent(
                 ) {
 
                     if (state.event.photos.isEmpty()
-                        && state.event.photosToUpload.isEmpty()
+//                        && state.event.photosToUpload.isEmpty()  // todo remove
                         && !state.isEditable
                     ) {
                         // • NO PHOTOS
@@ -437,43 +437,31 @@ fun AddEventScreenContent(
                                     .wrapContentHeight()
                                     .horizontalScroll(state = rememberScrollState())
                             ) {
-                                val photos =
-                                    remember(
-                                        state.event.photos.toMutableList(),
-                                        state.event.photosToUpload.toMutableList(),
-                                        state.isEditable
-                                    ) {
-                                        derivedStateOf {
-                                            var photoList = (state.event.photos)
-                                                .plus(state.event.photosToUpload)
+                                var photoList  = state.event.photos
 
-                                            // Add the "Add Photo" item if in edit mode
-                                            if (state.isEditable) {
-                                                if (photoList.isEmpty()) {
-                                                    photoList = listOf(
-                                                        Photo.Local(
-                                                            ADD_PHOTO_PLACEHOLDER,
-                                                            uri = Uri.EMPTY
-                                                        )
-                                                    )
-                                                } else {
-                                                    // Max 10 photos
-                                                    if (photoList.size <= 10) {
-                                                        photoList = photoList.plus(
-                                                            Photo.Local(
-                                                                ADD_PHOTO_PLACEHOLDER,
-                                                                uri = Uri.EMPTY
-                                                            )
-                                                        )
-                                                    }
-                                                }
-                                            }
-
-                                            photoList
+                                // Add the "Add Photo" button if in edit mode
+                                if (state.isEditable) {
+                                    if (photoList.isEmpty()) {
+                                        photoList = listOf(
+                                            Photo.Local(
+                                                ADD_PHOTO_PLACEHOLDER,
+                                                uri = Uri.EMPTY
+                                            )
+                                        )
+                                    } else {
+                                        // Max 10 photos
+                                        if (photoList.size <= 10) {
+                                            photoList = photoList.plus(
+                                                Photo.Local(
+                                                    ADD_PHOTO_PLACEHOLDER,
+                                                    uri = Uri.EMPTY
+                                                )
+                                            )
                                         }
                                     }
+                                }
 
-                                photos.value.forEachIndexed { index, photo ->
+                                photoList.forEachIndexed { index, photo ->
                                     // • Photo content box
                                     Box(
                                         modifier = Modifier

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -296,6 +296,7 @@ fun AddEventScreenContent(
                         )
                     }
 
+                    val editTextStyle = MaterialTheme.typography.h2  // can only access in Composable scope
                     Icon(
                         imageVector = Icons.Filled.ChevronRight,
                         tint = if (isEditable) MaterialTheme.colors.onSurface else Color.Transparent,
@@ -309,6 +310,7 @@ fun AddEventScreenContent(
                                     SetEditMode(
                                         EditMode.ChooseTitleText(
                                             state.event?.title ?: "",
+                                            editTextStyle = editTextStyle
                                         )
                                     )
                                 )
@@ -339,6 +341,7 @@ fun AddEventScreenContent(
                         )
                     }
 
+                    val editTextStyle = MaterialTheme.typography.body1  // can only access in Composable scope
                     Icon(
                         imageVector = Icons.Filled.ChevronRight,
                         tint = if (isEditable) MaterialTheme.colors.onSurface else Color.Transparent,
@@ -352,6 +355,7 @@ fun AddEventScreenContent(
                                     SetEditMode(
                                         EditMode.ChooseDescriptionText(
                                             state.event?.description ?: "",
+                                            editTextStyle = editTextStyle
                                         )
                                     )
                                 )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -438,15 +438,16 @@ fun AddEventScreenContent(
                                 val photos =
                                     remember(
                                         state.event.photos.toMutableList(),
-                                        state.event.photosToUpload?.toMutableList(),
+                                        state.event.photosToUpload.toMutableList(),
                                         state.isEditable
                                     ) {
                                         derivedStateOf {
                                             var photoList = (state.event.photos)
-                                                ?.plus(state.event.photosToUpload)
+                                                .plus(state.event.photosToUpload)
 
+                                            // Add the "Add Photo" item if in edit mode
                                             if (state.isEditable) {
-                                                if (photoList?.isEmpty() == true) {
+                                                if (photoList.isEmpty() == true) {
                                                     photoList = listOf(
                                                         Photo.Local(
                                                             "ADD_PHOTO_PLACEHOLDER",
@@ -455,7 +456,7 @@ fun AddEventScreenContent(
                                                     )
                                                 } else {
                                                     // Max 10 photos
-                                                    if (photoList?.size!! <= 10) {
+                                                    if (photoList.size <= 10) {
                                                         photoList = photoList.plus(
                                                             Photo.Local(
                                                                 "ADD_PHOTO_PLACEHOLDER",

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -193,7 +193,7 @@ fun AddEventScreenContent(
             )
 
             // • EDIT / SAVE BUTTON
-            if(state.event?.isUserEventCreator == true) {
+            if (state.event?.isUserEventCreator == true) {
                 if (isEditable) {
                     Text(
                         text = stringResource(R.string.event_save),
@@ -327,7 +327,8 @@ fun AddEventScreenContent(
                             .weight(1f)
                     ) {
                         Text(
-                            text = state.event?.description ?: stringResource(R.string.event_no_description_set),
+                            text = state.event?.description
+                                ?: stringResource(R.string.event_no_description_set),
                             style = MaterialTheme.typography.h5,
                             color = MaterialTheme.colors.onSurface,
                             modifier = Modifier
@@ -359,7 +360,7 @@ fun AddEventScreenContent(
             }
 
             // • PHOTO PICKER / ADD & REMOVE PHOTOS
-            if(state.event?.isUserEventCreator == true) {
+            if (state.event?.isUserEventCreator == true) {
                 Box(
                     modifier = Modifier
                         .background(MaterialTheme.colors.onSurface.copy(alpha = .1f))
@@ -389,7 +390,7 @@ fun AddEventScreenContent(
                                     onAction(SetIsEditable(true)) // turn on edit mode
                                 }
                         ) {
-                            // • Add Photo Icon
+                            // • ADD PHOTO ICON
                             Icon(
                                 imageVector = Icons.Filled.Add,
                                 tint = MaterialTheme.colors.onSurface.copy(alpha = .3f),
@@ -439,35 +440,37 @@ fun AddEventScreenContent(
                                         state.event?.photos?.toMutableList(),
                                         state.event?.photosToUpload?.toMutableList(),
                                         state.isEditable
-                                    )
-                                    {
-                                    derivedStateOf {
-                                        var photoList = (state.event?.photos)
-                                            ?.plus(state.event.photosToUpload)
+                                    ) {
+                                        derivedStateOf {
+                                            var photoList = (state.event?.photos)
+                                                ?.plus(state.event.photosToUpload)
 
-                                        if (state.isEditable) {
-                                            if (photoList.isNullOrEmpty()) {
-                                                photoList = listOf(
-                                                    Photo.Local(
-                                                        "ADD_PHOTO_PLACEHOLDER",
-                                                        uri = Uri.EMPTY
+                                            if (state.isEditable) {
+                                                if (photoList?.isEmpty() == true) {
+                                                    photoList = listOf(
+                                                        Photo.Local(
+                                                            "ADD_PHOTO_PLACEHOLDER",
+                                                            uri = Uri.EMPTY
+                                                        )
                                                     )
-                                                )
-                                            } else {
-                                                photoList = photoList.plus(
-                                                    Photo.Local(
-                                                        "ADD_PHOTO_PLACEHOLDER",
-                                                        uri = Uri.EMPTY
-                                                    )
-                                                )
+                                                } else {
+                                                    // Max 10 photos
+                                                    if (photoList?.size!! <= 10) {
+                                                        photoList = photoList.plus(
+                                                            Photo.Local(
+                                                                "ADD_PHOTO_PLACEHOLDER",
+                                                                uri = Uri.EMPTY
+                                                            )
+                                                        )
+                                                    }
+                                                }
                                             }
-                                        }
 
-                                        photoList
-                                }
+                                            photoList
+                                        }
                                     }
 
-                                photos.value?.forEach { photo ->
+                                photos.value?.forEachIndexed { index, photo ->
                                     // • Photo content box
                                     Box(
                                         modifier = Modifier
@@ -734,8 +737,8 @@ fun AddEventScreenContent(
                 // • JOIN/LEAVE/DELETE EVENT BUTTON
                 Text(
                     if (state.event?.isUserEventCreator == true) stringResource(R.string.event_delete_event)
-                        else if (state.event?.isGoing == true) stringResource(R.string.event_leave_event)
-                        else stringResource(R.string.event_join_event),
+                    else if (state.event?.isGoing == true) stringResource(R.string.event_leave_event)
+                    else stringResource(R.string.event_join_event),
                     style = MaterialTheme.typography.h4,
                     color = MaterialTheme.colors.onSurface.copy(alpha = 0.3f),
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -447,7 +447,7 @@ fun AddEventScreenContent(
 
                                             // Add the "Add Photo" item if in edit mode
                                             if (state.isEditable) {
-                                                if (photoList.isEmpty() == true) {
+                                                if (photoList.isEmpty()) {
                                                     photoList = listOf(
                                                         Photo.Local(
                                                             "ADD_PHOTO_PLACEHOLDER",

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -473,7 +473,7 @@ fun AddEventScreenContent(
                                         }
                                     }
 
-                                photos.value?.forEachIndexed { index, photo ->
+                                photos.value.forEachIndexed { index, photo ->
                                     // • Photo content box
                                     Box(
                                         modifier = Modifier

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -89,6 +89,8 @@ enum class AttendeeListType {
     NOT_GOING,
 }
 
+const val ADD_PHOTO_PLACEHOLDER = "ADD_PHOTO_PLACEHOLDER"
+
 @Composable
 fun AddEventScreenContent(
     state: EventScreenState,
@@ -450,7 +452,7 @@ fun AddEventScreenContent(
                                                 if (photoList.isEmpty()) {
                                                     photoList = listOf(
                                                         Photo.Local(
-                                                            "ADD_PHOTO_PLACEHOLDER",
+                                                            ADD_PHOTO_PLACEHOLDER,
                                                             uri = Uri.EMPTY
                                                         )
                                                     )
@@ -459,7 +461,7 @@ fun AddEventScreenContent(
                                                     if (photoList.size <= 10) {
                                                         photoList = photoList.plus(
                                                             Photo.Local(
-                                                                "ADD_PHOTO_PLACEHOLDER",
+                                                                ADD_PHOTO_PLACEHOLDER,
                                                                 uri = Uri.EMPTY
                                                             )
                                                         )
@@ -486,7 +488,7 @@ fun AddEventScreenContent(
                                     ) {
                                         when (photo) {
                                             is Photo.Local -> {
-                                                if (photo.id == "ADD_PHOTO_PLACEHOLDER") {
+                                                if (photo.id == ADD_PHOTO_PLACEHOLDER) {
                                                     // • Add Photo Icon
                                                     Icon(
                                                         imageVector = Icons.Filled.Add,
@@ -508,7 +510,7 @@ fun AddEventScreenContent(
                                                 } else {
                                                     AsyncImage(
                                                         model = photo.uri,
-                                                        contentDescription = "Photo",
+                                                        contentDescription = stringResource(id = R.string.event_description_photo),
                                                         modifier = Modifier.fillMaxWidth(),
                                                         contentScale = ContentScale.Crop
                                                     )
@@ -517,7 +519,7 @@ fun AddEventScreenContent(
                                             is Photo.Remote -> {
                                                 AsyncImage(
                                                     model = photo.url,
-                                                    contentDescription = "Photo",
+                                                    contentDescription = stringResource(id = R.string.event_description_photo),
                                                     modifier = Modifier.fillMaxWidth(),
                                                     contentScale = ContentScale.Crop
                                                 )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -437,12 +437,12 @@ fun AddEventScreenContent(
                             ) {
                                 val photos =
                                     remember(
-                                        state.event?.photos?.toMutableList(),
-                                        state.event?.photosToUpload?.toMutableList(),
+                                        state.event.photos.toMutableList(),
+                                        state.event.photosToUpload?.toMutableList(),
                                         state.isEditable
                                     ) {
                                         derivedStateOf {
-                                            var photoList = (state.event?.photos)
+                                            var photoList = (state.event.photos)
                                                 ?.plus(state.event.photosToUpload)
 
                                             if (state.isEditable) {

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt
@@ -1,6 +1,7 @@
 package com.realityexpander.tasky.agenda_feature.presentation.event_screen
 
 import android.content.res.Configuration
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.*
@@ -192,31 +193,33 @@ fun AddEventScreenContent(
             )
 
             // • EDIT / SAVE BUTTON
-            if (isEditable) {
-                Text(
-                    text = stringResource(R.string.event_save),
-                    color = MaterialTheme.colors.surface,
-                    textAlign = TextAlign.End,
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .alignByBaseline()
-                        .width(40.dp)
-                        .clickable {
-                            onAction(SetIsEditable(false))
-                        }
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Filled.Edit,
-                    tint = MaterialTheme.colors.surface,
-                    contentDescription = stringResource(R.string.event_description_edit_event),
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .width(40.dp)
-                        .clickable {
-                            onAction(SetIsEditable(true))
-                        }
-                )
+            if(state.event?.isUserEventCreator == true) {
+                if (isEditable) {
+                    Text(
+                        text = stringResource(R.string.event_save),
+                        color = MaterialTheme.colors.surface,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically)
+                            .alignByBaseline()
+                            .width(40.dp)
+                            .clickable {
+                                onAction(SetIsEditable(false))
+                            }
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Edit,
+                        tint = MaterialTheme.colors.surface,
+                        contentDescription = stringResource(R.string.event_description_edit_event),
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically)
+                            .width(40.dp)
+                            .clickable {
+                                onAction(SetIsEditable(true))
+                            }
+                    )
+                }
             }
 
         }
@@ -356,122 +359,172 @@ fun AddEventScreenContent(
             }
 
             // • PHOTO PICKER / ADD & REMOVE PHOTOS
-            Box(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.onSurface.copy(alpha = .1f))
-                    .fillMaxWidth()
-                    .padding(DP.small)
-                    .border(0.dp, Color.Transparent)
-                    .wrapContentHeight()
-            ) {
-
-                if (state.event?.photos.isNullOrEmpty()
-                    && state.event?.photosToUpload.isNullOrEmpty()
+            if(state.event?.isUserEventCreator == true) {
+                Box(
+                    modifier = Modifier
+                        .background(MaterialTheme.colors.onSurface.copy(alpha = .1f))
+                        .fillMaxWidth()
+                        .padding(DP.small)
+                        .border(0.dp, Color.Transparent)
+                        .wrapContentHeight()
                 ) {
-                    // • NO PHOTOS
-                    Row(
-                        horizontalArrangement = Arrangement.Center,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .align(Alignment.Center)
-                            .padding(top = DP.medium, bottom = DP.medium)
-                            .clickable { //(enabled = isEditable) {
-                                onAction(
-                                    SetEditMode(
-                                        EditMode.ChooseAddPhoto()
-                                    )
-                                )
-                            }
+
+                    if (state.event.photos.isEmpty()
+                        && state.event.photosToUpload.isEmpty()
+                        && !state.isEditable
                     ) {
-                        // • Add Photo Icon
-                        Icon(
-                            imageVector = Icons.Filled.Add,
-                            tint = MaterialTheme.colors.onSurface.copy(alpha = .3f),
-                            contentDescription = stringResource(R.string.event_description_add_photo),
-                            modifier = Modifier
-                                .size(26.dp)
-                        )
-                        Spacer(modifier = Modifier.smallWidth())
-                        Text(
-                            stringResource(R.string.event_add_photos),
-                            modifier = Modifier
-                                .offset(y = 2.dp),
-                            fontWeight = Bold,
-                            color = MaterialTheme.colors.onSurface.copy(alpha = .3f)
-                        )
-                    }
-                } else {
-                    // • LIST OF PHOTO IMAGES
-                    Column(
-                        modifier = Modifier
-                            .wrapContentHeight()
-                    ) {
-                        // • Photos Header
+                        // • NO PHOTOS
                         Row(
-                            horizontalArrangement = Arrangement.Start,
+                            horizontalArrangement = Arrangement.Center,
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .align(Alignment.Center)
+                                .padding(top = DP.medium, bottom = DP.medium)
+                                .clickable {
+                                    onAction(
+                                        SetEditMode(
+                                            EditMode.ChooseAddPhoto()
+                                        )
+                                    )
+                                    onAction(SetIsEditable(true)) // turn on edit mode
+                                }
                         ) {
+                            // • Add Photo Icon
+                            Icon(
+                                imageVector = Icons.Filled.Add,
+                                tint = MaterialTheme.colors.onSurface.copy(alpha = .3f),
+                                contentDescription = stringResource(R.string.event_description_add_photo),
+                                modifier = Modifier
+                                    .size(26.dp)
+                            )
+                            Spacer(modifier = Modifier.smallWidth())
                             Text(
-                                stringResource(R.string.event_photos),
-                                color = MaterialTheme.colors.onSurface,
-                                style = MaterialTheme.typography.h3,
-                                fontWeight = SemiBold,
+                                stringResource(R.string.event_add_photos),
+                                modifier = Modifier
+                                    .offset(y = 2.dp),
+                                fontWeight = Bold,
+                                color = MaterialTheme.colors.onSurface.copy(alpha = .3f)
                             )
                         }
-                        Spacer(modifier = Modifier.extraSmallHeight())
-
-                        // • Photo Items
-                        Row(
+                    } else {
+                        // • LIST OF PHOTO IMAGES
+                        Column(
                             modifier = Modifier
-                                .fillMaxWidth()
                                 .wrapContentHeight()
-                                .horizontalScroll(state = rememberScrollState())
                         ) {
+                            // • Photos Header
+                            Row(
+                                horizontalArrangement = Arrangement.Start,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                            ) {
+                                Text(
+                                    stringResource(R.string.event_photos),
+                                    color = MaterialTheme.colors.onSurface,
+                                    style = MaterialTheme.typography.h3,
+                                    fontWeight = SemiBold,
+                                )
+                            }
+                            Spacer(modifier = Modifier.extraSmallHeight())
 
-//                            state.event?.photos?.forEach {  // todo  - show remote photos
-                            state.event?.photosToUpload?.forEach { photoLocal ->
-                                // • Photo content box
-                                Box(
-                                    modifier = Modifier
-                                        .size(60.dp)
-                                        .clip(RoundedCornerShape(10.dp))
-                                        .background(Color.Transparent)
-                                        .border(
-                                            2.dp,  // Border width
-                                            MaterialTheme.colors.onSurface.copy(alpha = .3f),
-                                            RoundedCornerShape(10.dp)
-                                        )
-                                ) {
-                                    // • Add Photo Icon
-                                    Icon(
-                                        imageVector = Icons.Filled.Add,
-                                        tint = MaterialTheme.colors.onSurface.copy(alpha = .3f),
-                                        contentDescription = stringResource(R.string.event_description_add_photo),
-                                        modifier = Modifier
-                                            .size(36.dp)
-                                            .align(Alignment.Center)
-                                            .clickable(enabled = isEditable) {
-                                                onAction(
-                                                    SetEditMode(
-                                                        EditMode.ChooseAddPhoto()
+                            // • Photo Items
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .wrapContentHeight()
+                                    .horizontalScroll(state = rememberScrollState())
+                            ) {
+                                val photos =
+                                    remember(
+                                        state.event?.photos?.toMutableList(),
+                                        state.event?.photosToUpload?.toMutableList(),
+                                        state.isEditable
+                                    )
+                                    {
+                                    derivedStateOf {
+                                        var photoList = (state.event?.photos)
+                                            ?.plus(state.event.photosToUpload)
+
+                                        if (state.isEditable) {
+                                            if (photoList.isNullOrEmpty()) {
+                                                photoList = listOf(
+                                                    Photo.Local(
+                                                        "ADD_PHOTO_PLACEHOLDER",
+                                                        uri = Uri.EMPTY
+                                                    )
+                                                )
+                                            } else {
+                                                photoList = photoList.plus(
+                                                    Photo.Local(
+                                                        "ADD_PHOTO_PLACEHOLDER",
+                                                        uri = Uri.EMPTY
                                                     )
                                                 )
                                             }
-                                    )
+                                        }
 
-                                    // • Photo Image
-                                    AsyncImage(
-                                        model = photoLocal.uri,
-                                        contentDescription = "Photo",
-                                        modifier = Modifier.fillMaxWidth(),
-                                        contentScale = ContentScale.Crop
+                                        photoList
+                                }
+                                    }
+
+                                photos.value?.forEach { photo ->
+                                    // • Photo content box
+                                    Box(
+                                        modifier = Modifier
+                                            .size(60.dp)
+                                            .clip(RoundedCornerShape(10.dp))
+                                            .background(Color.Transparent)
+                                            .border(
+                                                2.dp,  // Border width
+                                                MaterialTheme.colors.onSurface.copy(alpha = .3f),
+                                                RoundedCornerShape(10.dp)
+                                            )
+                                    ) {
+                                        when (photo) {
+                                            is Photo.Local -> {
+                                                if (photo.id == "ADD_PHOTO_PLACEHOLDER") {
+                                                    // • Add Photo Icon
+                                                    Icon(
+                                                        imageVector = Icons.Filled.Add,
+                                                        tint = MaterialTheme.colors.onSurface.copy(
+                                                            alpha = .3f
+                                                        ),
+                                                        contentDescription = stringResource(R.string.event_description_add_photo),
+                                                        modifier = Modifier
+                                                            .size(36.dp)
+                                                            .align(Alignment.Center)
+                                                            .clickable(enabled = isEditable) {
+                                                                onAction(
+                                                                    SetEditMode(
+                                                                        EditMode.ChooseAddPhoto()
+                                                                    )
+                                                                )
+                                                            }
+                                                    )
+                                                } else {
+                                                    AsyncImage(
+                                                        model = photo.uri,
+                                                        contentDescription = "Photo",
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        contentScale = ContentScale.Crop
+                                                    )
+                                                }
+                                            }
+                                            is Photo.Remote -> {
+                                                AsyncImage(
+                                                    model = photo.url,
+                                                    contentDescription = "Photo",
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    contentScale = ContentScale.Crop
+                                                )
+                                            }
+                                        }
+                                    }
+                                    Spacer(
+                                        modifier = Modifier
+                                            .width(10.dp)
                                     )
                                 }
-                                Spacer(
-                                    modifier = Modifier
-                                        .width(10.dp)
-                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreenEvent.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreenEvent.kt
@@ -1,5 +1,6 @@
 package com.realityexpander.tasky.agenda_feature.presentation.event_screen
 
+import androidx.compose.ui.text.TextStyle
 import com.realityexpander.tasky.R
 import com.realityexpander.tasky.agenda_feature.common.util.AttendeeId
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
@@ -36,19 +37,25 @@ sealed interface EventScreenEvent {
 
     sealed interface EditMode {
 
+        // Dialog Display values
         abstract val dialogTitle: UiText
+        sealed interface EditTextStyle { // dialog uses a specific text style
+            val editTextStyle: TextStyle
+        }
 
         // • (1) WHICH item is being edited?
         // - sets initial/default value and the dialog display string)
         data class ChooseTitleText(
             override val text: String = "",
-            override val dialogTitle: UiText = UiText.Res(R.string.event_dialog_title_choose_title_text)
-        ) : EditMode, TextPayload
+            override val dialogTitle: UiText = UiText.Res(R.string.event_dialog_title_choose_title_text),
+            override val editTextStyle: TextStyle = TextStyle.Default
+        ) : EditMode, EditTextStyle, TextPayload
 
         data class ChooseDescriptionText(
             override val text: String = "",
-            override val dialogTitle: UiText = UiText.Res(R.string.event_dialog_title_choose_description_text)
-        ) : EditMode, TextPayload
+            override val dialogTitle: UiText = UiText.Res(R.string.event_dialog_title_choose_description_text),
+            override val editTextStyle: TextStyle = TextStyle.Default
+        ) : EditMode, EditTextStyle, TextPayload
 
         data class ChooseFromDate(
             override val dateTime: ZonedDateTime = ZonedDateTime.now(),

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreenEvent.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreenEvent.kt
@@ -97,7 +97,7 @@ sealed interface EventScreenEvent {
             val dateTime: ZonedDateTime
         }
         sealed interface PhotoPayload {
-            val photo: Photo
+            val photoLocal: Photo.Local
         }
         sealed interface PhotoIdPayload {
             val photoId: PhotoId
@@ -113,7 +113,7 @@ sealed interface EventScreenEvent {
         // • (3) FINALLY "Update Data" Events - Delivers the edited/added/deleted data payload to the ViewModel
         data class UpdateText(override val text: String) : EventScreenEvent, TextPayload
         data class UpdateDateTime(override val dateTime: ZonedDateTime) : EventScreenEvent, DateTimePayload
-        data class AddPhoto(override val photo: Photo) : EventScreenEvent, PhotoPayload
+        data class AddPhoto(override val photoLocal: Photo.Local) : EventScreenEvent, PhotoPayload
         data class RemovePhoto(override val photoId: PhotoId) : EventScreenEvent, PhotoIdPayload
         data class AddAttendee(override val attendee: Attendee) : EventScreenEvent, AttendeePayload
         data class RemoveAttendee(override val attendeeId: AttendeeId) : EventScreenEvent, AttendeeIdPayload

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
@@ -4,10 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.realityexpander.tasky.R
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.Attendee
-import com.realityexpander.tasky.agenda_feature.domain.IAgendaRepository
-import com.realityexpander.tasky.agenda_feature.domain.ResultUiText
+import com.realityexpander.tasky.agenda_feature.domain.*
 import com.realityexpander.tasky.agenda_feature.presentation.common.util.max
 import com.realityexpander.tasky.agenda_feature.presentation.common.util.min
 import com.realityexpander.tasky.agenda_feature.presentation.event_screen.EventScreenEvent.*
@@ -84,6 +81,12 @@ class EventViewModel @Inject constructor(
                     to = ZonedDateTime.now().plusHours(2),
                     remindAt = ZonedDateTime.now().plusMinutes(30),
                     isGoing = true,
+                    photos = listOf(
+                        Photo.Remote(
+                            UUID.randomUUID().toString(),
+                            "https://randomuser.me/api/portraits/men/75.jpg"
+                        )
+                    ),
                     attendees = listOf(
                         Attendee(
                             eventId = "0001",

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
@@ -351,7 +351,7 @@ class EventViewModel @Inject constructor(
                 _state.update { _state ->
                     _state.copy(
                         event = _state.event?.copy(
-                            photosToUpload = _state.event.photosToUpload + uiEvent.photoLocal
+                            photos = _state.event.photos + uiEvent.photoLocal
                         ),
                         editMode = null
                     )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
@@ -79,7 +79,7 @@ class EventViewModel @Inject constructor(
                     id = "0001",
                     title = "Title of Event",
                     description = "Description of Event",
-                    isUserEventCreator = false,
+                    isUserEventCreator = true,
                     from = ZonedDateTime.now().plusHours(1),
                     to = ZonedDateTime.now().plusHours(2),
                     remindAt = ZonedDateTime.now().plusMinutes(30),

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventViewModel.kt
@@ -344,6 +344,16 @@ class EventViewModel @Inject constructor(
                     else -> throw java.lang.IllegalStateException("Invalid type for SaveDateTime: ${_state.value.editMode}")
                 }
             }
+            is EditMode.AddPhoto -> {
+                _state.update { _state ->
+                    _state.copy(
+                        event = _state.event?.copy(
+                            photosToUpload = _state.event.photosToUpload + uiEvent.photoLocal
+                        ),
+                        editMode = null
+                    )
+                }
+            }
             is EditMode.AddAttendee -> {
                 _state.update { _state ->
                     _state.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="event_description_edit_event_description">Edit Event Description</string>
     <string name="event_description_add_photo">Add photo</string>
     <string name="event_description_add_attendee_button">Add Attendee button</string>
+    <string name="event_description_photo">Photo</string>
     <string name="event_save">Save</string>
     <string name="event_event_title">Event</string>
     <string name="event_no_title_set">No title set</string>


### PR DESCRIPTION
* Conform Cancel button behavior to match "tap-outside" and "cancel" button for Add Attendee dialog
* Add ability to add photos
* UI Lists both URL and URI photos
* Limits number of photos to 10
* Add sample photo URLs
* Use `PickVisualMediaRequest` to select photos

## Question 1

Is this a good & proper use of `derivedStateOf`:

https://github.com/realityexpander/Tasky/blob/8123fd3af6be2ba218b7274b2454615d025a7952/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/event_screen/EventScreen.kt#L440-L474