### PR TITLE
0033 refactor repo use sep get update

### DIFF
--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
@@ -75,7 +75,6 @@ class AgendaRepositoryImpl @Inject constructor(
 //        return flow { // why doesnt this work?
         return channelFlow {
             supervisorScope {
-                launch(Dispatchers.IO) {
                     try {
                         updateAgendaForDayFromRemote(dateTime)
 
@@ -101,8 +100,6 @@ class AgendaRepositoryImpl @Inject constructor(
                     }
 
                 }
-
-            }
         }
     }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
@@ -79,6 +79,7 @@ class AgendaRepositoryImpl @Inject constructor(
                     try {
                         updateAgendaForDayFromRemote(dateTime)
 
+                        // This doesn't work with `flow`, why not?
 //                        emitAll(taskRepository.getTasksForDayFlow(dateTime).combine(
 //                            eventRepository.getEventsForDayFlow(dateTime)
 //                        ) { tasks, events ->
@@ -94,9 +95,6 @@ class AgendaRepositoryImpl @Inject constructor(
 //                            emit(agendaItems)
                         }
                     }
-//                    catch (e: CancellationException) {            // not needed here?
-//                        /* intentionally eat this exception */
-//                    }
                     catch (e: Exception) {
                         e.printStackTrace()
                         // don't send error to user, just log it (silent fail is ok here)

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt
@@ -10,7 +10,7 @@ import com.realityexpander.tasky.agenda_feature.data.repositories.attendeeReposi
 import com.realityexpander.tasky.agenda_feature.domain.*
 import com.realityexpander.tasky.core.presentation.common.util.UiText
 import com.realityexpander.tasky.core.util.Email
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -38,39 +38,52 @@ class AgendaRepositoryImpl @Inject constructor(
         return events + tasks // + reminders
     }
 
+    override suspend fun updateAgendaForDayFromRemote(dateTime: ZonedDateTime) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                // Get fresh data
+                val result = agendaApi.getAgenda(dateTime)
+
+//                eventRepository.clearEventsForDayLocally(dateTime) // clear local data // todo add this?
+                // Insert fresh data into db
+                result.events.forEach { event ->
+                    val result2 =
+                        eventRepository.upsertEventLocally(event.toDomain())
+                    if(result2 is ResultUiText.Error) {
+                        throw IllegalStateException(result2.message.asStrOrNull())
+                    }
+                }
+
+//                taskRepository.clearTasksForDayLocally(dateTime) // clear local data // todo add this?
+                // Insert fresh data into db
+                result.tasks.forEach { task ->
+                    val result2 =
+                        taskRepository.upsertTaskLocally(task.toDomain())
+                    if(result2 is ResultUiText.Error) {
+                        throw IllegalStateException(result2.message.asStrOrNull())
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                // don't send error to user, just log it (silent fail is ok here)
+            }
+        }
+    }
+
     override fun getAgendaForDayFlow(dateTime: ZonedDateTime): Flow<List<AgendaItem>> {
 
+//        return flow { // why doesnt this work?
         return channelFlow {
             supervisorScope {
                 launch(Dispatchers.IO) {
                     try {
-                        // send stale local data
-                        send(eventRepository.getEventsForDay(dateTime) +
-                                taskRepository.getTasksForDay(dateTime)
-                        )
+                        updateAgendaForDayFromRemote(dateTime)
 
-                        // Get fresh data
-                        val result = agendaApi.getAgenda(dateTime)
-
-//                        eventRepository.clearEventsForDayLocally(dateTime) // clear local data // todo add this?
-                        // Insert fresh data into db
-                        result.events.forEach { event ->
-                            val result2 =
-                                eventRepository.upsertEventLocally(event.toDomain())
-                            if(result2 is ResultUiText.Error) {
-                                throw IllegalStateException(result2.message.asStrOrNull())
-                            }
-                        }
-
-//                        taskRepository.clearTasksForDayLocally(dateTime) // clear local data // todo add this?
-                        // Insert fresh data into db
-                        result.tasks.forEach { task ->
-                            val result2 =
-                                taskRepository.upsertTaskLocally(task.toDomain())
-                            if(result2 is ResultUiText.Error) {
-                                throw IllegalStateException(result2.message.asStrOrNull())
-                            }
-                        }
+//                        emitAll(taskRepository.getTasksForDayFlow(dateTime).combine(
+//                            eventRepository.getEventsForDayFlow(dateTime)
+//                        ) { tasks, events ->
+//                            events + tasks // + reminders
+//                        })
 
                         taskRepository.getTasksForDayFlow(dateTime).combine(
                             eventRepository.getEventsForDayFlow(dateTime)
@@ -78,11 +91,12 @@ class AgendaRepositoryImpl @Inject constructor(
                             events + tasks // + reminders
                         }.collect { agendaItems ->
                             send(agendaItems)
+//                            emit(agendaItems)
                         }
                     }
-                    catch (e: CancellationException) {
-                        /* intentionally eat this exception */
-                    }
+//                    catch (e: CancellationException) {            // not needed here?
+//                        /* intentionally eat this exception */
+//                    }
                     catch (e: Exception) {
                         e.printStackTrace()
                         // don't send error to user, just log it (silent fail is ok here)

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/IAgendaRepository.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/IAgendaRepository.kt
@@ -12,6 +12,7 @@ interface IAgendaRepository {
     suspend fun getAgendaForDay(dateTime: ZonedDateTime): List<AgendaItem>
     fun getAgendaForDayFlow(dateTime: ZonedDateTime): Flow<List<AgendaItem>>
     suspend fun syncAgenda(): ResultUiText<Void>
+    suspend fun updateAgendaForDayFromRemote(dateTime: ZonedDateTime)
 
     // • Event Repository
     suspend fun createEvent(event: AgendaItem.Event): ResultUiText<AgendaItem.Event>
@@ -37,5 +38,4 @@ interface IAgendaRepository {
 //    suspend fun updateReminder(reminder: AgendaItem.Reminder): Boolean
 //    suspend fun deleteReminder(reminderId: ReminderId): Boolean
 //    suspend fun deleteAllReminders(): Boolean
-
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
@@ -91,6 +91,9 @@ class AgendaViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            agendaRepository.updateAgendaForDayFromRemote(
+                getDateForSelectedDayIndex(selectedDate, selectedDayIndex)
+            )
             yield() // wait for other init code to run
 
             // restore state after process death


### PR DESCRIPTION
* Separate out the `get` and `update` into two repo functions

## QUESTION 1
Im still having issues with using `emit` and `emitAll` with my setup:

https://github.com/realityexpander/Tasky/blob/43730d876d24f31883a8899867cb04c3992126ef/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepostoryImpl.kt#L82-L87

Is there something fundamental that I've set up wrong to make `send` work properly and `emit` and `emitAll` do not work?