### PR TITLE
0044 refactor attempt to save `ZonedDateTime` to db, refactor to eliminate redundant `remindAt`

### DIFF
--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/AttendeeConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/AttendeeConverters.kt
@@ -3,7 +3,7 @@ package com.realityexpander.tasky.agenda_feature.data.common.convertersDTOEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities.AttendeeEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.DTOs.AttendeeDTO
 import com.realityexpander.tasky.agenda_feature.domain.Attendee
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
 
 
@@ -27,7 +27,7 @@ fun Attendee.toDTO() =
         email = email,
         fullName = fullName,
         isGoing = isGoing,
-        remindAt = remindAt?.toUtcMillis(),
+        remindAt = remindAt?.toEpochMilli(),
         photo = photo,
     )
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
@@ -9,7 +9,7 @@ import com.realityexpander.tasky.agenda_feature.domain.Attendee
 import com.realityexpander.tasky.agenda_feature.domain.Photo
 import com.realityexpander.tasky.agenda_feature.presentation.common.util.isUserIdGoingAsAttendee
 import com.realityexpander.tasky.core.util.UserId
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -70,7 +70,7 @@ fun EventDTO.toDomain(): AgendaItem.Event {
                 description = description,
                 from = from.toZonedDateTime(),
                 to = to.toZonedDateTime(),
-                remindAt = remindAt.toZonedDateTime(),
+                remindAt = remindAtMilli.toZonedDateTime(),
 
                 host = host,
                 isUserEventCreator = isUserEventCreator,
@@ -92,9 +92,9 @@ fun AgendaItem.Event.toEventDTOCreate(): EventDTO.Create {
         id = id,
         title = title,
         description = description,
-        from = from.toUtcMillis(),
-        to = to.toUtcMillis(),
-        remindAt = remindAt.toUtcMillis(),
+        from = from.toEpochMilli(),
+        to = to.toEpochMilli(),
+        remindAtMilli = remindAt.toEpochMilli(),
         attendeeIds = attendees.map { attendee ->
             attendee.id
         },
@@ -111,9 +111,9 @@ fun AgendaItem.Event.toEventDTOUpdate(authUserId: UserId? = null): EventDTO.Upda
         id = id,
         title = title,
         description = description,
-        from = from.toUtcMillis(),
-        to = to.toUtcMillis(),
-        remindAt = remindAt.toUtcMillis(),
+        from = from.toEpochMilli(),
+        to = to.toEpochMilli(),
+        remindAtMilli = remindAt.toEpochMilli(),
         isGoing = isUserIdGoingAsAttendee(authUserId, attendees),
         attendeeIds = attendees.map { attendee ->
             attendee.id
@@ -132,9 +132,9 @@ fun AgendaItem.Event.toEventDTOResponse(): EventDTO.Response {
         id = id,
         title = title,
         description = description,
-        from = from.toUtcMillis(),
-        to = to.toUtcMillis(),
-        remindAt = remindAt.toUtcMillis(),
+        from = from.toEpochMilli(),
+        to = to.toEpochMilli(),
+        remindAtMilli = remindAt.toEpochMilli(),
         photos = photos
             .map { it.toDTO() }
             .filterIsInstance<PhotoDTO.Remote>(),        // guarantee only respond with Remote photos

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/EventConverters.kt
@@ -70,7 +70,7 @@ fun EventDTO.toDomain(): AgendaItem.Event {
                 description = description,
                 from = from.toZonedDateTime(),
                 to = to.toZonedDateTime(),
-                remindAt = remindAtMilli.toZonedDateTime(),
+                remindAt = remindAt.toZonedDateTime(),
 
                 host = host,
                 isUserEventCreator = isUserEventCreator,
@@ -94,7 +94,7 @@ fun AgendaItem.Event.toEventDTOCreate(): EventDTO.Create {
         description = description,
         from = from.toEpochMilli(),
         to = to.toEpochMilli(),
-        remindAtMilli = remindAt.toEpochMilli(),
+        remindAt = remindAt.toEpochMilli(),
         attendeeIds = attendees.map { attendee ->
             attendee.id
         },
@@ -113,7 +113,7 @@ fun AgendaItem.Event.toEventDTOUpdate(authUserId: UserId? = null): EventDTO.Upda
         description = description,
         from = from.toEpochMilli(),
         to = to.toEpochMilli(),
-        remindAtMilli = remindAt.toEpochMilli(),
+        remindAt = remindAt.toEpochMilli(),
         isGoing = isUserIdGoingAsAttendee(authUserId, attendees),
         attendeeIds = attendees.map { attendee ->
             attendee.id
@@ -134,7 +134,7 @@ fun AgendaItem.Event.toEventDTOResponse(): EventDTO.Response {
         description = description,
         from = from.toEpochMilli(),
         to = to.toEpochMilli(),
-        remindAtMilli = remindAt.toEpochMilli(),
+        remindAt = remindAt.toEpochMilli(),
         photos = photos
             .map { it.toDTO() }
             .filterIsInstance<PhotoDTO.Remote>(),        // guarantee only respond with Remote photos

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/ReminderConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/ReminderConverters.kt
@@ -39,7 +39,7 @@ fun ReminderDTO.toDomain(): AgendaItem.Reminder {
         id = id,
         title = title,
         description = description,
-        remindAt = remindAtMilli.toZonedDateTime(),
+        remindAt = remindAt.toZonedDateTime(),
         time = time.toZonedDateTime(),
         isSynced = true
     )
@@ -52,7 +52,7 @@ fun AgendaItem.Reminder.toDTO(): ReminderDTO {
         title = title,
         description = description,
         time = time.toEpochMilli(),
-        remindAtMilli = remindAt.toEpochMilli(),
+        remindAt = remindAt.toEpochMilli(),
     )
 }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/ReminderConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/ReminderConverters.kt
@@ -4,7 +4,7 @@ import com.google.gson.GsonBuilder
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.entities.ReminderEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.DTOs.ReminderDTO
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -39,7 +39,7 @@ fun ReminderDTO.toDomain(): AgendaItem.Reminder {
         id = id,
         title = title,
         description = description,
-        remindAt = remindAt.toZonedDateTime(),
+        remindAt = remindAtMilli.toZonedDateTime(),
         time = time.toZonedDateTime(),
         isSynced = true
     )
@@ -51,8 +51,8 @@ fun AgendaItem.Reminder.toDTO(): ReminderDTO {
         id = id,
         title = title,
         description = description,
-        time = time.toUtcMillis(),
-        remindAt = remindAt.toUtcMillis(),
+        time = time.toEpochMilli(),
+        remindAtMilli = remindAt.toEpochMilli(),
     )
 }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/TaskConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/TaskConverters.kt
@@ -4,7 +4,7 @@ import com.google.gson.GsonBuilder
 import com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.local.entities.TaskEntity
 import com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.remote.DTOs.TaskDTO
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -41,7 +41,7 @@ fun TaskDTO.toDomain(): AgendaItem.Task {
         id = id,
         title = title,
         description = description,
-        remindAt = remindAt.toZonedDateTime(),
+        remindAt = remindAtMilli.toZonedDateTime(),
         time = time.toZonedDateTime(),
         isDone = isDone,
         isSynced = true
@@ -54,8 +54,8 @@ fun AgendaItem.Task.toDTO(): TaskDTO {
         id = id,
         title = title,
         description = description,
-        time = time.toUtcMillis(),
-        remindAt = remindAt.toUtcMillis(),
+        time = time.toEpochMilli(),
+        remindAtMilli = remindAt.toEpochMilli(),
         isDone = isDone,
     )
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/TaskConverters.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/convertersDTOEntityDomain/TaskConverters.kt
@@ -41,7 +41,7 @@ fun TaskDTO.toDomain(): AgendaItem.Task {
         id = id,
         title = title,
         description = description,
-        remindAt = remindAtMilli.toZonedDateTime(),
+        remindAt = remindAt.toZonedDateTime(),
         time = time.toZonedDateTime(),
         isDone = isDone,
         isSynced = true
@@ -55,7 +55,7 @@ fun AgendaItem.Task.toDTO(): TaskDTO {
         title = title,
         description = description,
         time = time.toEpochMilli(),
-        remindAtMilli = remindAt.toEpochMilli(),
+        remindAt = remindAt.toEpochMilli(),
         isDone = isDone,
     )
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/ZonedDateTimeTypeConverter.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/ZonedDateTimeTypeConverter.kt
@@ -2,37 +2,11 @@ package com.realityexpander.tasky.agenda_feature.data.common.typeConverters
 
 import androidx.room.TypeConverter
 import com.realityexpander.tasky.core.util.EpochSecond
-import com.realityexpander.tasky.core.util.ZonedDateTimeStr
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-
-class ZonedDateTimeTypeConverter2 {
-    @TypeConverter
-    fun fromZonedDateTime(value: ZonedDateTime?): ZonedDateTimeStr? {  // saves as a String (ZonedDateTime Format) in DB Tables
-        return value?.toInstant()
-            ?.atZone(ZoneOffset.UTC)
-            ?.truncatedTo(ChronoUnit.MINUTES)
-            ?.toString()
-    }
-
-    @TypeConverter
-    fun toZonedDateTime(value: ZonedDateTimeStr?): ZonedDateTime? {   // restores from a String (ZonedDateTime Format) in DB Tables
-        return value?.let {
-            ZonedDateTime.ofInstant(
-                Instant.from(
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'")
-                        .withZone(ZoneId.of("UTC"))
-                        .parse(value)
-                ),
-                ZoneId.systemDefault()  // convert to current local time zone
-            )
-        }
-    }
-}
 
 class ZonedDateTimeTypeConverter {
     @TypeConverter
@@ -42,7 +16,6 @@ class ZonedDateTimeTypeConverter {
             ?.truncatedTo(ChronoUnit.MINUTES)
             ?.toEpochSecond()
     }
-
     @TypeConverter
     fun toZonedDateTime(value: EpochSecond?): ZonedDateTime? {   // restores from a Long (UTC epochSeconds) in DB Tables
         return value?.let {
@@ -52,9 +25,8 @@ class ZonedDateTimeTypeConverter {
             )
         }
     }
+
 }
-
-
 
 //// Local Test ////
 
@@ -86,3 +58,44 @@ fun main() {
     println(nycNowLong2)
     println(nycNowLong == nycNowLong2)
 }
+
+
+// LEFT FOR REFERENCE
+// Room database does query comparisons in the SQL database based on primitives only. So, if you
+// use a custom type, you need to convert it to a primitive type that Room will use to make
+// comparisons in the SQL queries. For dates this is always going to be a long.
+//
+// For example, if you have a custom type called Date, you should convert it to a long value that
+// represents the number of milliseconds since January 1, 1970, 00:00:00 GMT. Then, Room will use
+// the long value to compare dates in queries. If you don't convert the custom type to a primitive
+// type that Room can compare (like a long), Room will compare the string representation of the
+// custom type, which is not what you want.
+//
+// https://developer.android.com/training/data-storage/room/referencing-data
+//
+// This shows the wrong approach to converting a custom type that needs to be compared using a Room query.
+// In this incorrect example, the custom type is a Date object. The Date object is converted to a string.
+// Room uses the string representation of the Date object to compare dates. This is not what you want.
+//class ZonedDateTimeTypeConverter2 {
+//    @TypeConverter
+//    fun fromZonedDateTime(value: ZonedDateTime?): ZonedDateTimeStr? {  // saves as a String (ZonedDateTime Format) in DB Tables
+//        return value?.toInstant()
+//            ?.atZone(ZoneOffset.UTC)
+//            ?.truncatedTo(ChronoUnit.MINUTES)
+//            ?.toString()
+//    }
+//
+//    @TypeConverter
+//    fun toZonedDateTime(value: ZonedDateTimeStr?): ZonedDateTime? {   // restores from a String (ZonedDateTime Format) in DB Tables
+//        return value?.let {
+//            ZonedDateTime.ofInstant(
+//                Instant.from(
+//                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'")
+//                        .withZone(ZoneId.of("UTC"))
+//                        .parse(value)
+//                ),
+//                ZoneId.systemDefault()  // convert to current local time zone
+//            )
+//        }
+//    }
+//}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/ZonedDateTimeTypeConverter.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/typeConverters/ZonedDateTimeTypeConverter.kt
@@ -1,16 +1,42 @@
 package com.realityexpander.tasky.agenda_feature.data.common.typeConverters
 
 import androidx.room.TypeConverter
-import com.realityexpander.tasky.core.util.UtcSeconds
+import com.realityexpander.tasky.core.util.EpochSecond
+import com.realityexpander.tasky.core.util.ZonedDateTimeStr
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+
+class ZonedDateTimeTypeConverter2 {
+    @TypeConverter
+    fun fromZonedDateTime(value: ZonedDateTime?): ZonedDateTimeStr? {  // saves as a String (ZonedDateTime Format) in DB Tables
+        return value?.toInstant()
+            ?.atZone(ZoneOffset.UTC)
+            ?.truncatedTo(ChronoUnit.MINUTES)
+            ?.toString()
+    }
+
+    @TypeConverter
+    fun toZonedDateTime(value: ZonedDateTimeStr?): ZonedDateTime? {   // restores from a String (ZonedDateTime Format) in DB Tables
+        return value?.let {
+            ZonedDateTime.ofInstant(
+                Instant.from(
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'")
+                        .withZone(ZoneId.of("UTC"))
+                        .parse(value)
+                ),
+                ZoneId.systemDefault()  // convert to current local time zone
+            )
+        }
+    }
+}
 
 class ZonedDateTimeTypeConverter {
     @TypeConverter
-    fun fromZonedDateTime(value: ZonedDateTime?): UtcSeconds? {  // saves as a Long (UTC epochSeconds) in DB Tables
+    fun fromZonedDateTime(value: ZonedDateTime?): EpochSecond? {  // saves as a Long (UTC epochSeconds) in DB Tables
         return value?.toInstant()
             ?.atZone(ZoneOffset.UTC)
             ?.truncatedTo(ChronoUnit.MINUTES)
@@ -18,7 +44,7 @@ class ZonedDateTimeTypeConverter {
     }
 
     @TypeConverter
-    fun toZonedDateTime(value: UtcSeconds?): ZonedDateTime? {   // restores from a Long (UTC epochSeconds) in DB Tables
+    fun toZonedDateTime(value: EpochSecond?): ZonedDateTime? {   // restores from a Long (UTC epochSeconds) in DB Tables
         return value?.let {
             ZonedDateTime.ofInstant(
                 Instant.ofEpochSecond(value),

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/remote/AgendaApiImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/remote/AgendaApiImpl.kt
@@ -4,7 +4,7 @@ import com.realityexpander.tasky.agenda_feature.data.repositories.agendaReposito
 import com.realityexpander.tasky.core.data.remote.TaskyApi
 import com.realityexpander.tasky.core.data.remote.utils.cancelExistingApiCallWithSameParameterValue
 import com.realityexpander.tasky.core.util.rethrowIfCancellation
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import okhttp3.OkHttpClient
 import java.time.ZonedDateTime
 import javax.inject.Inject
@@ -20,12 +20,12 @@ class AgendaApiImpl @Inject constructor(
             cancelExistingApiCallWithSameParameterValue(
                 okHttpClient,
                 "date",
-                zonedDateTime.toUtcMillis().toString()
+                zonedDateTime.toEpochMilli().toString()
             )
 
             val response = taskyApi.getAgenda(
                 ZonedDateTime.now().zone.id.toString(),
-                zonedDateTime.toUtcMillis()
+                zonedDateTime.toEpochMilli()
             )
 
             if (response.isSuccessful) {

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/attendeeRepository/remote/DTOs/AttendeeDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/attendeeRepository/remote/DTOs/AttendeeDTO.kt
@@ -4,7 +4,7 @@ import com.realityexpander.tasky.agenda_feature.common.util.AttendeeId
 import com.realityexpander.tasky.agenda_feature.common.util.EventId
 import com.realityexpander.tasky.agenda_feature.common.util.UrlStr
 import com.realityexpander.tasky.core.util.Email
-import com.realityexpander.tasky.core.util.UtcMillis
+import com.realityexpander.tasky.core.util.EpochMilli
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
@@ -19,7 +19,7 @@ data class AttendeeDTO(
     val email: Email,
     val fullName: String,
     val isGoing: Boolean = false,
-    val remindAt: UtcMillis? = null,
+    val remindAt: EpochMilli? = null,
 
     val photo: UrlStr? = null,
 )

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
@@ -1,10 +1,10 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities
 
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -27,8 +27,8 @@ data class EventEntity constructor(
     val deletedPhotoIds: List<PhotoId> = emptyList(),
 
     val isSynced: Boolean = false,
-) : AgendaItem() {
+) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
 
-    @Ignore
-    override val startTime: ZonedDateTime = from
+//    @Ignore
+//    override val startTime: ZonedDateTime = from
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
@@ -1,19 +1,21 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.entities
 
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
+import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
 @Entity(tableName = "events")
-data class EventEntity(
+data class EventEntity constructor(
     @PrimaryKey(autoGenerate = false)
-    val id: UuidStr,
+    override val id: UuidStr,
 
-    val title: String,
-    val description: String,
-    val remindAt: ZonedDateTime,
+    override val title: String,
+    override val description: String,
+    override val remindAt: ZonedDateTime,
     val from: ZonedDateTime,
     val to: ZonedDateTime,
 
@@ -24,5 +26,9 @@ data class EventEntity(
     val photos: List<PhotoEntity> = emptyList(),
     val deletedPhotoIds: List<PhotoId> = emptyList(),
 
-    val isSynced: Boolean = false
-)
+    val isSynced: Boolean = false,
+) : AgendaItem() {
+
+    @Ignore
+    override val startTime: ZonedDateTime = from
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/entities/EventEntity.kt
@@ -4,7 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
+import com.realityexpander.tasky.agenda_feature.domain.UsesZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -27,8 +27,4 @@ data class EventEntity constructor(
     val deletedPhotoIds: List<PhotoId> = emptyList(),
 
     val isSynced: Boolean = false,
-) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
-
-//    @Ignore
-//    override val startTime: ZonedDateTime = from
-}
+) : AbstractAgendaItem(), UsesZonedDateTime

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/eventDao/eventDaoImpls/EventDaoImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/local/eventDao/eventDaoImpls/EventDaoImpl.kt
@@ -38,7 +38,7 @@ interface EventDaoImpl : IEventDao {
     @Query(
         """
         SELECT * FROM events WHERE  
-            ( `remindAt` >= :startDateTime) AND (`remindAt` < :endDateTime) -- remindAt starts within range
+            ( remindAt >= :startDateTime) AND (remindAt < :endDateTime) -- remindAt starts within range
         """
     )
     override fun getLocalEventsForRemindAtDateTimeRangeFlow(

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -58,7 +58,7 @@ abstract class EventDTO : AbstractAgendaItem(), UsesEpochMilli {
 
     @Serializable
     @OptIn(ExperimentalSerializationApi::class) // for JsonNames
-    data class Response constructor(  // server RESPONSE only
+    data class Response constructor(  // RESPONSE only
         override val id: UuidStr,
         override val title: String,
         override val description: String,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -33,11 +33,11 @@ abstract class EventDTO : AgendaItem() {
         @Transient  // This field is used to store Local URI's for photos to upload.
         val photos: List<PhotoDTO.Local> = emptyList(),  // only local URI's are stored here
 
-        // Unused fields for transfer to server (useful for debugging)
+        // Transient fields (won't send to server)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        override val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime()
+        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
 
@@ -63,11 +63,11 @@ abstract class EventDTO : AgendaItem() {
         @Transient
         val photos: List<PhotoDTO.Local> = emptyList(), // Local URI's are stored here for uploading
 
-        // Unused fields for transfer to server (useful for debugging)
+        // Transient fields (won't send to server)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        override val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime()
+        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
     @Serializable
@@ -88,10 +88,10 @@ abstract class EventDTO : AgendaItem() {
         // Note: Returns complete Photo objects (not Ids)
         val photos: List<PhotoDTO.Remote> = emptyList(),  // NOTE: Only Remote photos are returned
 
-        // Unused fields for transfer from server (useful for debugging)
+        // Transient fields (won't come from server)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        override val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime()
+        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -2,17 +2,16 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.eventReposito
 
 import com.realityexpander.tasky.agenda_feature.common.util.AttendeeId
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
 import com.realityexpander.tasky.agenda_feature.util.*
 import com.realityexpander.tasky.core.util.*
 import kotlinx.serialization.*
-import kotlinx.serialization.json.JsonNames
-import java.time.ZonedDateTime
 
-abstract class EventDTO : AgendaItem() {
+abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
 
     // Core information for all Event DTO Types
-    abstract val remindAtMilli: EpochMilli
+//    abstract val remindAtMilli: EpochMilli
     abstract val from: EpochMilli
     abstract val to: EpochMilli
 
@@ -22,8 +21,8 @@ abstract class EventDTO : AgendaItem() {
         override val title: String,
         override val description: String,
 
-        @SerialName("remindAt")
-        override val remindAtMilli: EpochMilli,
+//        @SerialName("remindAt")
+        override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
 
@@ -34,10 +33,10 @@ abstract class EventDTO : AgendaItem() {
         val photos: List<PhotoDTO.Local> = emptyList(),  // only local URI's are stored here
 
         // Transient fields (won't send to server)
-        @Transient
-        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-        @Transient
-        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
+//        @Transient
+//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
+//        @Transient
+//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
 
@@ -47,8 +46,8 @@ abstract class EventDTO : AgendaItem() {
         override val title: String,
         override val description: String,
 
-        @SerialName("remindAt")
-        override val remindAtMilli: EpochMilli,
+//        @SerialName("remindAt")
+        override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
 
@@ -66,10 +65,10 @@ abstract class EventDTO : AgendaItem() {
         val photos: List<PhotoDTO.Local> = emptyList(), // Local URI's are stored here for uploading
 
         // Transient fields (won't send to server)
-        @Transient
-        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-        @Transient
-        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
+//        @Transient
+//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
+//        @Transient
+//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
     @Serializable
@@ -79,8 +78,8 @@ abstract class EventDTO : AgendaItem() {
         override val title: String,
         override val description: String,
 
-        @JsonNames("remindAt") // json input field name
-        override val remindAtMilli: EpochMilli,
+//        @JsonNames("remindAt") // json input field name
+        override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
 
@@ -94,9 +93,9 @@ abstract class EventDTO : AgendaItem() {
         val photos: List<PhotoDTO.Remote> = emptyList(),  // NOTE: Only Remote photos are returned
 
         // Transient fields (won't come from server)
-        @Transient
-        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-        @Transient
-        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
+//        @Transient
+//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
+//        @Transient
+//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -4,28 +4,28 @@ import com.realityexpander.tasky.agenda_feature.common.util.AttendeeId
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.agenda_feature.util.*
-import com.realityexpander.tasky.core.util.UserId
-import com.realityexpander.tasky.core.util.UtcMillis
-import com.realityexpander.tasky.core.util.UuidStr
-import com.realityexpander.tasky.core.util.toZonedDateTime
+import com.realityexpander.tasky.core.util.*
 import kotlinx.serialization.*
+import kotlinx.serialization.json.JsonNames
 import java.time.ZonedDateTime
 
 abstract class EventDTO : AgendaItem() {
 
-    // Core information for all Event DTOs
-    abstract val remindAt: UtcMillis
-    abstract val from: UtcMillis
-    abstract val to: UtcMillis
+    // Core information for all Event DTO Types
+    abstract val from: EpochMilli
+    abstract val to: EpochMilli
+    abstract val remindAtMilli: EpochMilli
 
     @Serializable
     data class Create(  // POST only
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        override val remindAt: UtcMillis,
-        override val from: UtcMillis,
-        override val to: UtcMillis,
+
+        @SerialName("remindAt")
+        override val remindAtMilli: EpochMilli,
+        override val from: EpochMilli,
+        override val to: EpochMilli,
 
         @Required  // forces write of empty list -> []   (instead of no field written)
         val attendeeIds: List<AttendeeId> = emptyList(),
@@ -37,7 +37,7 @@ abstract class EventDTO : AgendaItem() {
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
+        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
 
@@ -46,9 +46,11 @@ abstract class EventDTO : AgendaItem() {
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        override val remindAt: UtcMillis,
-        override val from: UtcMillis,
-        override val to: UtcMillis,
+
+        @SerialName("remindAt")
+        override val remindAtMilli: EpochMilli,
+        override val from: EpochMilli,
+        override val to: EpochMilli,
 
         @Required
         val isGoing : Boolean,  // ONLY used to set `isGoing` status for `UpdateEventDTO`, not used anywhere else in app.
@@ -67,17 +69,20 @@ abstract class EventDTO : AgendaItem() {
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
+        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
     @Serializable
-    data class Response(  // server response only
+    @OptIn(ExperimentalSerializationApi::class) // for JsonNames
+    data class Response constructor(  // server RESPONSE only
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        override val remindAt: UtcMillis,
-        override val from: UtcMillis,
-        override val to: UtcMillis,
+
+        @JsonNames("remindAt") // json input field name
+        override val remindAtMilli: EpochMilli,
+        override val from: EpochMilli,
+        override val to: EpochMilli,
 
         val host: UserId,
         val isUserEventCreator: Boolean,
@@ -92,6 +97,6 @@ abstract class EventDTO : AgendaItem() {
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
-        val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime() // (useful for debugging)
+        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -14,15 +14,12 @@ import java.time.ZonedDateTime
 abstract class EventDTO : AgendaItem() {
 
     // Core information for all Event DTOs
-//    abstract val id: UuidStr
-//    abstract val title: String
-//    abstract val description: String
     abstract val remindAt: UtcMillis
     abstract val from: UtcMillis
     abstract val to: UtcMillis
 
     @Serializable
-    data class Create(  // output only
+    data class Create(  // POST only
         override val id: UuidStr,
         override val title: String,
         override val description: String,
@@ -36,7 +33,7 @@ abstract class EventDTO : AgendaItem() {
         @Transient  // This field is used to store Local URI's for photos to upload.
         val photos: List<PhotoDTO.Local> = emptyList(),  // only local URI's are stored here
 
-        // Unused fields
+        // Unused fields for transfer to server (useful for debugging)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
@@ -45,7 +42,7 @@ abstract class EventDTO : AgendaItem() {
 
 
     @Serializable
-    data class Update(  // output only
+    data class Update(  // PUT only
         override val id: UuidStr,
         override val title: String,
         override val description: String,
@@ -60,13 +57,13 @@ abstract class EventDTO : AgendaItem() {
         val attendeeIds: List<AttendeeId> = emptyList(),
 
         @Required
-        @SerialName("deletedPhotoKeys") // output to json
+        @SerialName("deletedPhotoKeys") // json output field name
         val deletedPhotoIds: List<PhotoId> = emptyList(),
 
         @Transient
         val photos: List<PhotoDTO.Local> = emptyList(), // Local URI's are stored here for uploading
 
-        // Unused fields
+        // Unused fields for transfer to server (useful for debugging)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient
@@ -74,7 +71,7 @@ abstract class EventDTO : AgendaItem() {
     ) : EventDTO()
 
     @Serializable
-    data class Response(  // input only
+    data class Response(  // server response only
         override val id: UuidStr,
         override val title: String,
         override val description: String,
@@ -91,7 +88,7 @@ abstract class EventDTO : AgendaItem() {
         // Note: Returns complete Photo objects (not Ids)
         val photos: List<PhotoDTO.Remote> = emptyList(),  // NOTE: Only Remote photos are returned
 
-        // Unused fields
+        // Unused fields for transfer from server (useful for debugging)
         @Transient
         override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
         @Transient

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -3,15 +3,14 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.eventReposito
 import com.realityexpander.tasky.agenda_feature.common.util.AttendeeId
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
+import com.realityexpander.tasky.agenda_feature.domain.UsesEpochMilli
 import com.realityexpander.tasky.agenda_feature.util.*
 import com.realityexpander.tasky.core.util.*
 import kotlinx.serialization.*
 
-abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
+abstract class EventDTO : AbstractAgendaItem(), UsesEpochMilli {
 
     // Core information for all Event DTO Types
-//    abstract val remindAtMilli: EpochMilli
     abstract val from: EpochMilli
     abstract val to: EpochMilli
 
@@ -21,7 +20,6 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
         override val title: String,
         override val description: String,
 
-//        @SerialName("remindAt")
         override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
@@ -31,12 +29,6 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
 
         @Transient  // This field is used to store Local URI's for photos to upload.
         val photos: List<PhotoDTO.Local> = emptyList(),  // only local URI's are stored here
-
-        // Transient fields (won't send to server)
-//        @Transient
-//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-//        @Transient
-//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
 
@@ -46,7 +38,6 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
         override val title: String,
         override val description: String,
 
-//        @SerialName("remindAt")
         override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
@@ -63,12 +54,6 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
 
         @Transient
         val photos: List<PhotoDTO.Local> = emptyList(), // Local URI's are stored here for uploading
-
-        // Transient fields (won't send to server)
-//        @Transient
-//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-//        @Transient
-//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 
     @Serializable
@@ -78,7 +63,6 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
         override val title: String,
         override val description: String,
 
-//        @JsonNames("remindAt") // json input field name
         override val remindAt: EpochMilli,
         override val from: EpochMilli,
         override val to: EpochMilli,
@@ -91,11 +75,5 @@ abstract class EventDTO : AbstractAgendaItem(), HasTimeAsEpochMilli {
 
         // Note: Returns complete Photo objects (not Ids)
         val photos: List<PhotoDTO.Remote> = emptyList(),  // NOTE: Only Remote photos are returned
-
-        // Transient fields (won't come from server)
-//        @Transient
-//        override val startTime: ZonedDateTime = from.toZonedDateTime(),  // for sorting in Agenda
-//        @Transient
-//        override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime() // (useful for debugging)
     ) : EventDTO()
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/eventRepository/remote/eventApi/DTOs/EventDTO.kt
@@ -12,9 +12,9 @@ import java.time.ZonedDateTime
 abstract class EventDTO : AgendaItem() {
 
     // Core information for all Event DTO Types
+    abstract val remindAtMilli: EpochMilli
     abstract val from: EpochMilli
     abstract val to: EpochMilli
-    abstract val remindAtMilli: EpochMilli
 
     @Serializable
     data class Create(  // POST only

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/IReminderDao.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/IReminderDao.kt
@@ -1,4 +1,4 @@
-package com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.local
+package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local
 
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.entities.ReminderEntity

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
@@ -1,9 +1,9 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.entities
 
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -18,8 +18,8 @@ data class ReminderEntity(
     val time: ZonedDateTime,
 
     val isSynced: Boolean = false,
-) : AgendaItem() {
+) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
 
-    @Ignore
-    override val startTime: ZonedDateTime = time
+//    @Ignore
+//    override val startTime: ZonedDateTime = time
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
@@ -1,19 +1,25 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.entities
 
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
 @Entity(tableName = "reminders")
 data class ReminderEntity(
     @PrimaryKey(autoGenerate = false)
-    val id: UuidStr,
+    override val id: UuidStr,
 
-    val title: String,
-    val description: String,
-    val remindAt: ZonedDateTime,
+    override val title: String,
+    override val description: String,
+    override val remindAt: ZonedDateTime,
     val time: ZonedDateTime,
 
-    val isSynced: Boolean = false
-)
+    val isSynced: Boolean = false,
+) : AgendaItem() {
+
+    @Ignore
+    override val startTime: ZonedDateTime = time
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/entities/ReminderEntity.kt
@@ -3,7 +3,7 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepos
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
+import com.realityexpander.tasky.agenda_feature.domain.UsesZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -18,8 +18,4 @@ data class ReminderEntity(
     val time: ZonedDateTime,
 
     val isSynced: Boolean = false,
-) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
-
-//    @Ignore
-//    override val startTime: ZonedDateTime = time
-}
+) : AbstractAgendaItem(), UsesZonedDateTime

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/reminderDao/reminderDaoImpls/ReminderDaoImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/local/reminderDao/reminderDaoImpls/ReminderDaoImpl.kt
@@ -1,7 +1,7 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.reminderDao.reminderDaoImpls
 
 import androidx.room.*
-import com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.entities.ReminderEntity
 import com.realityexpander.tasky.core.util.DAY_IN_SECONDS
@@ -38,9 +38,10 @@ interface ReminderDaoImpl : IReminderDao {
     @Query(
         """
         SELECT * FROM reminders 
-            WHERE ( ( `remindAt` >= :startDateTime) AND (`remindAt` < :endDateTime) ) -- remindAt starts this day
+            WHERE ( ( remindAt >= :startDateTime) AND (remindAt < :endDateTime) ) -- remindAt starts this day
                 
-        """)
+        """
+    )
     override fun getLocalRemindersForRemindAtDateTimeRangeFlow(
         startDateTime: ZonedDateTime,
         endDateTime: ZonedDateTime

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/reminderRepositoryImpls/ReminderRepositoryImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/reminderRepositoryImpls/ReminderRepositoryImpl.kt
@@ -1,9 +1,9 @@
-package com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls
+package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls
 
 import com.realityexpander.remindery.agenda_feature.data.common.convertersDTOEntityDomain.toDTO
 import com.realityexpander.remindery.agenda_feature.data.common.convertersDTOEntityDomain.toDomain
 import com.realityexpander.remindery.agenda_feature.data.common.convertersDTOEntityDomain.toEntity
-import com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
 import com.realityexpander.tasky.R
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.IReminderApi

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
@@ -2,7 +2,7 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepos
 
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
+import com.realityexpander.tasky.agenda_feature.domain.UsesEpochMilli
 import com.realityexpander.tasky.core.util.EpochMilli
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
@@ -14,13 +14,6 @@ data class ReminderDTO constructor(
     override val title: String,
     override val description: String,
 
-//    @SerialName("remindAt")
-//    @JsonNames("remindAt") // json input field name
     override val remindAt: EpochMilli,
     val time: EpochMilli,
-
-//    @Transient
-//    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
-//    @Transient
-//    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
-) : AbstractAgendaItem(), HasTimeAsEpochMilli
+) : AbstractAgendaItem(), UsesEpochMilli

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
@@ -1,15 +1,11 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.DTOs
 
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
 import com.realityexpander.tasky.core.util.EpochMilli
-import com.realityexpander.tasky.core.util.toZonedDateTime
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
-import kotlinx.serialization.json.JsonNames
-import java.time.ZonedDateTime
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class) // for JsonNames
@@ -18,13 +14,13 @@ data class ReminderDTO constructor(
     override val title: String,
     override val description: String,
 
-    @SerialName("remindAt")
-    @JsonNames("remindAt") // json input field name
-    val remindAtMilli: EpochMilli,
+//    @SerialName("remindAt")
+//    @JsonNames("remindAt") // json input field name
+    override val remindAt: EpochMilli,
     val time: EpochMilli,
 
-    @Transient
-    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
-    @Transient
-    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
-) : AgendaItem()
+//    @Transient
+//    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
+//    @Transient
+//    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
+) : AbstractAgendaItem(), HasTimeAsEpochMilli

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/DTOs/ReminderDTO.kt
@@ -2,22 +2,29 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepos
 
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
-import com.realityexpander.tasky.core.util.UtcMillis
+import com.realityexpander.tasky.core.util.EpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import kotlinx.serialization.json.JsonNames
 import java.time.ZonedDateTime
 
 @Serializable
-data class ReminderDTO(
+@OptIn(ExperimentalSerializationApi::class) // for JsonNames
+data class ReminderDTO constructor(
     override val id: ReminderId,
     override val title: String,
     override val description: String,
-    val remindAt: UtcMillis,
-    val time: UtcMillis,
+
+    @SerialName("remindAt")
+    @JsonNames("remindAt") // json input field name
+    val remindAtMilli: EpochMilli,
+    val time: EpochMilli,
 
     @Transient
     override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
     @Transient
-    override val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime(),
+    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
 ) : AgendaItem()

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/reminderApi/reminderApiImpls/ReminderApiImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/reminderRepository/remote/reminderApi/reminderApiImpls/ReminderApiImpl.kt
@@ -1,4 +1,4 @@
-package com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls
+package com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls
 
 import android.accounts.NetworkErrorException
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
@@ -1,9 +1,9 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.local.entities
 
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.PrimaryKey
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -19,8 +19,8 @@ data class TaskEntity(
     val isDone: Boolean,
 
     val isSynced: Boolean = false,
-) : AgendaItem() {
+) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
 
-    @Ignore
-    override val startTime: ZonedDateTime = time
+//    @Ignore
+//    override val startTime: ZonedDateTime = time
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
@@ -3,7 +3,7 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepositor
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsZonedDateTime
+import com.realityexpander.tasky.agenda_feature.domain.UsesZonedDateTime
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
@@ -19,8 +19,4 @@ data class TaskEntity(
     val isDone: Boolean,
 
     val isSynced: Boolean = false,
-) : AbstractAgendaItem(), HasTimeAsZonedDateTime {
-
-//    @Ignore
-//    override val startTime: ZonedDateTime = time
-}
+) : AbstractAgendaItem(), UsesZonedDateTime

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/entities/TaskEntity.kt
@@ -1,20 +1,26 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.local.entities
 
 import androidx.room.Entity
+import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.core.util.UuidStr
 import java.time.ZonedDateTime
 
 @Entity(tableName = "tasks")
 data class TaskEntity(
     @PrimaryKey(autoGenerate = false)
-    val id: UuidStr,
+    override val id: UuidStr,
 
-    val title: String,
-    val description: String,
-    val remindAt: ZonedDateTime,
+    override val title: String,
+    override val description: String,
+    override val remindAt: ZonedDateTime,
     val time: ZonedDateTime,
     val isDone: Boolean,
 
-    val isSynced: Boolean = false
-)
+    val isSynced: Boolean = false,
+) : AgendaItem() {
+
+    @Ignore
+    override val startTime: ZonedDateTime = time
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/taskDao/taskDaoImpls/TaskDaoImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/local/taskDao/taskDaoImpls/TaskDaoImpl.kt
@@ -57,8 +57,9 @@ interface TaskDaoImpl : ITaskDao {
     @Query(
         """
         SELECT * FROM tasks WHERE 
-            ( `remindAt` >= :startDateTime) AND (`remindAt` < :endDateTime) -- remindAt starts within DateTime range
-        """)
+            ( remindAt >= :startDateTime) AND (remindAt < :endDateTime) -- remindAt starts within DateTime range
+        """
+    )
     override fun getTasksForRemindAtDateTimeRangeFlow(
         startDateTime: ZonedDateTime,
         endDateTime: ZonedDateTime

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
@@ -1,12 +1,10 @@
 package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.remote.DTOs
 
 import com.realityexpander.tasky.agenda_feature.common.util.TaskId
-import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
+import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
 import com.realityexpander.tasky.core.util.EpochMilli
-import com.realityexpander.tasky.core.util.toZonedDateTime
 import kotlinx.serialization.*
-import kotlinx.serialization.json.JsonNames
-import java.time.ZonedDateTime
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class) // for JsonNames
@@ -15,16 +13,16 @@ data class TaskDTO(
     override val title: String,
     override val description: String,
 
-    @SerialName("remindAt")
-    @JsonNames("remindAt") // json input field name
-    val remindAtMilli: EpochMilli,
+//    @SerialName("remindAt")
+//    @JsonNames("remindAt") // json input field name
+    override val remindAt: EpochMilli,
     val time: EpochMilli,
 
     @Required
     val isDone: Boolean = false,
 
-    @Transient
-    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
-    @Transient
-    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
-) : AgendaItem()
+//    @Transient
+//    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
+//    @Transient
+//    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
+) : AbstractAgendaItem(), HasTimeAsEpochMilli

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
@@ -2,7 +2,7 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepositor
 
 import com.realityexpander.tasky.agenda_feature.common.util.TaskId
 import com.realityexpander.tasky.agenda_feature.domain.AbstractAgendaItem
-import com.realityexpander.tasky.agenda_feature.domain.HasTimeAsEpochMilli
+import com.realityexpander.tasky.agenda_feature.domain.UsesEpochMilli
 import com.realityexpander.tasky.core.util.EpochMilli
 import kotlinx.serialization.*
 
@@ -25,4 +25,4 @@ data class TaskDTO(
 //    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
 //    @Transient
 //    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
-) : AbstractAgendaItem(), HasTimeAsEpochMilli
+) : AbstractAgendaItem(), UsesEpochMilli

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
@@ -2,21 +2,23 @@ package com.realityexpander.tasky.agenda_feature.data.repositories.taskRepositor
 
 import com.realityexpander.tasky.agenda_feature.common.util.TaskId
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
-import com.realityexpander.tasky.core.util.UtcMillis
+import com.realityexpander.tasky.core.util.EpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
-import kotlinx.serialization.Required
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
+import kotlinx.serialization.json.JsonNames
 import java.time.ZonedDateTime
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class) // for JsonNames
 data class TaskDTO(
     override val id: TaskId,
     override val title: String,
     override val description: String,
 
-    val remindAt: UtcMillis,
-    val time: UtcMillis,
+    @SerialName("remindAt")
+    @JsonNames("remindAt") // json input field name
+    val remindAtMilli: EpochMilli,
+    val time: EpochMilli,
 
     @Required
     val isDone: Boolean = false,
@@ -24,5 +26,5 @@ data class TaskDTO(
     @Transient
     override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
     @Transient
-    override val remindAtTime: ZonedDateTime = remindAt.toZonedDateTime(),
+    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
 ) : AgendaItem()

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/taskRepository/remote/DTOs/TaskDTO.kt
@@ -13,16 +13,9 @@ data class TaskDTO(
     override val title: String,
     override val description: String,
 
-//    @SerialName("remindAt")
-//    @JsonNames("remindAt") // json input field name
     override val remindAt: EpochMilli,
     val time: EpochMilli,
 
     @Required
     val isDone: Boolean = false,
-
-//    @Transient
-//    override val startTime: ZonedDateTime = time.toZonedDateTime(), // for sorting in Agenda
-//    @Transient
-//    override val remindAt: ZonedDateTime = remindAtMilli.toZonedDateTime(), // for debugging
 ) : AbstractAgendaItem(), UsesEpochMilli

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -2,18 +2,30 @@ package com.realityexpander.tasky.agenda_feature.domain
 
 import android.os.Parcelable
 import com.realityexpander.tasky.agenda_feature.common.util.PhotoId
+import com.realityexpander.tasky.core.util.EpochMilli
 import com.realityexpander.tasky.core.util.UserId
 import com.realityexpander.tasky.core.util.UuidStr
 import kotlinx.parcelize.Parcelize
 import java.time.ZonedDateTime
 
-abstract class AgendaItem {
+//    abstract val id: UuidStr
+//    abstract val title: String
+//    abstract val description: String
+//    abstract val remindAt: ZonedDateTime
 
+abstract class AbstractAgendaItem {
     abstract val id: UuidStr
     abstract val title: String
     abstract val description: String
-    abstract val remindAt: ZonedDateTime
-    abstract val startTime: ZonedDateTime  // for sorting in Agenda
+}
+
+abstract class AgendaItem :
+    AbstractAgendaItem(),
+    HasTimeAsZonedDateTime, 
+    HasStartTime
+{
+
+//    abstract val startTime: ZonedDateTime  // for sorting in Agenda
 
     @Parcelize
     data class Event(
@@ -50,7 +62,6 @@ abstract class AgendaItem {
 
         val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
-
     @Parcelize
     data class Reminder(
         override val id: UuidStr,
@@ -63,4 +74,16 @@ abstract class AgendaItem {
 
         val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
+}
+
+interface HasTimeAsZonedDateTime {
+    val remindAt: ZonedDateTime
+}
+
+interface HasTimeAsEpochMilli {
+    val remindAt: EpochMilli
+}
+
+interface HasStartTime {
+    val startTime: ZonedDateTime
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -20,7 +20,6 @@ abstract class AgendaItem {
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        val isSynced: Boolean = false,
 
         val from: ZonedDateTime,
         val to: ZonedDateTime,
@@ -33,6 +32,8 @@ abstract class AgendaItem {
 
         val photos: List<Photo> = emptyList(),
         val deletedPhotoIds: List<PhotoId> = emptyList(),  // only used for EventDTO.Update
+
+        val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
 
     @Parcelize
@@ -40,13 +41,14 @@ abstract class AgendaItem {
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        val isSynced: Boolean = false,
 
         val time: ZonedDateTime,
         override val startTime: ZonedDateTime = time, // for sorting in Agenda
         override val remindAt: ZonedDateTime,
 
         val isDone: Boolean = false,
+
+        val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
 
     @Parcelize
@@ -54,10 +56,11 @@ abstract class AgendaItem {
         override val id: UuidStr,
         override val title: String,
         override val description: String,
-        val isSynced: Boolean = false,
 
         val time: ZonedDateTime,
         override val startTime: ZonedDateTime = time, // for sorting in Agenda
         override val remindAt: ZonedDateTime,
+
+        val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -7,11 +7,12 @@ import com.realityexpander.tasky.core.util.UuidStr
 import kotlinx.parcelize.Parcelize
 import java.time.ZonedDateTime
 
-abstract class AgendaItem : java.io.Serializable {
+abstract class AgendaItem {
 
     abstract val id: UuidStr
     abstract val title: String
     abstract val description: String
+    abstract val remindAt: ZonedDateTime
     abstract val startTime: ZonedDateTime  // for sorting in Agenda
 
     @Parcelize
@@ -22,9 +23,9 @@ abstract class AgendaItem : java.io.Serializable {
         val isSynced: Boolean = false,
 
         val from: ZonedDateTime,
-        override var startTime: ZonedDateTime = from, // for sorting in Agenda
         val to: ZonedDateTime,
-        val remindAt: ZonedDateTime,
+        override val startTime: ZonedDateTime = from, // for sorting in Agenda
+        override val remindAt: ZonedDateTime,
 
         val host: UserId? = null,
         val isUserEventCreator: Boolean = false,
@@ -32,7 +33,7 @@ abstract class AgendaItem : java.io.Serializable {
 
         val photos: List<Photo> = emptyList(),
         val deletedPhotoIds: List<PhotoId> = emptyList(),  // only used for EventDTO.Update
-    ) : AgendaItem(), Parcelable, java.io.Serializable
+    ) : AgendaItem(), Parcelable
 
     @Parcelize
     data class Task(
@@ -42,11 +43,11 @@ abstract class AgendaItem : java.io.Serializable {
         val isSynced: Boolean = false,
 
         val time: ZonedDateTime,
-        override var startTime: ZonedDateTime = time, // for sorting in Agenda
-        val remindAt: ZonedDateTime,
+        override val startTime: ZonedDateTime = time, // for sorting in Agenda
+        override val remindAt: ZonedDateTime,
 
         val isDone: Boolean = false,
-    ) : AgendaItem(), Parcelable, java.io.Serializable
+    ) : AgendaItem(), Parcelable
 
     @Parcelize
     data class Reminder(
@@ -56,7 +57,7 @@ abstract class AgendaItem : java.io.Serializable {
         val isSynced: Boolean = false,
 
         val time: ZonedDateTime,
-        override var startTime: ZonedDateTime = time, // for sorting in Agenda
-        val remindAt: ZonedDateTime,
-    ) : AgendaItem(), Parcelable, java.io.Serializable
+        override val startTime: ZonedDateTime = time, // for sorting in Agenda
+        override val remindAt: ZonedDateTime,
+    ) : AgendaItem(), Parcelable
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -54,6 +54,7 @@ abstract class AgendaItem :
 
         val isSynced: Boolean = false,
     ) : AgendaItem(), Parcelable
+
     @Parcelize
     data class Reminder(
         override val id: UuidStr,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -13,7 +13,6 @@ abstract class AgendaItem : java.io.Serializable {
     abstract val title: String
     abstract val description: String
     abstract val startTime: ZonedDateTime  // for sorting in Agenda
-    abstract val remindAtTime: ZonedDateTime
 
     @Parcelize
     data class Event(
@@ -26,11 +25,9 @@ abstract class AgendaItem : java.io.Serializable {
         override var startTime: ZonedDateTime = from, // for sorting in Agenda
         val to: ZonedDateTime,
         val remindAt: ZonedDateTime,
-        override var remindAtTime: ZonedDateTime = remindAt,
 
         val host: UserId? = null,
         val isUserEventCreator: Boolean = false,
-
         val attendees: List<Attendee> = emptyList(),
 
         val photos: List<Photo> = emptyList(),
@@ -47,7 +44,6 @@ abstract class AgendaItem : java.io.Serializable {
         val time: ZonedDateTime,
         override var startTime: ZonedDateTime = time, // for sorting in Agenda
         val remindAt: ZonedDateTime,
-        override var remindAtTime: ZonedDateTime = remindAt,
 
         val isDone: Boolean = false,
     ) : AgendaItem(), Parcelable, java.io.Serializable
@@ -62,6 +58,5 @@ abstract class AgendaItem : java.io.Serializable {
         val time: ZonedDateTime,
         override var startTime: ZonedDateTime = time, // for sorting in Agenda
         val remindAt: ZonedDateTime,
-        override var remindAtTime: ZonedDateTime = remindAt,
     ) : AgendaItem(), Parcelable, java.io.Serializable
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/AgendaItem.kt
@@ -8,11 +8,6 @@ import com.realityexpander.tasky.core.util.UuidStr
 import kotlinx.parcelize.Parcelize
 import java.time.ZonedDateTime
 
-//    abstract val id: UuidStr
-//    abstract val title: String
-//    abstract val description: String
-//    abstract val remindAt: ZonedDateTime
-
 abstract class AbstractAgendaItem {
     abstract val id: UuidStr
     abstract val title: String
@@ -21,12 +16,9 @@ abstract class AbstractAgendaItem {
 
 abstract class AgendaItem :
     AbstractAgendaItem(),
-    HasTimeAsZonedDateTime, 
+    UsesZonedDateTime,
     HasStartTime
 {
-
-//    abstract val startTime: ZonedDateTime  // for sorting in Agenda
-
     @Parcelize
     data class Event(
         override val id: UuidStr,
@@ -76,11 +68,11 @@ abstract class AgendaItem :
     ) : AgendaItem(), Parcelable
 }
 
-interface HasTimeAsZonedDateTime {
+interface UsesZonedDateTime {
     val remindAt: ZonedDateTime
 }
 
-interface HasTimeAsEpochMilli {
+interface UsesEpochMilli {
     val remindAt: EpochMilli
 }
 

--- a/app/src/main/java/com/realityexpander/tasky/core/data/remote/TaskyApi.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/remote/TaskyApi.kt
@@ -15,7 +15,7 @@ import com.realityexpander.tasky.auth_feature.data.repository.remote.DTOs.auth.A
 import com.realityexpander.tasky.auth_feature.data.repository.remote.util.createAuthorizationHeader
 import com.realityexpander.tasky.core.util.AuthToken
 import com.realityexpander.tasky.core.util.Email
-import com.realityexpander.tasky.core.util.UtcMillis
+import com.realityexpander.tasky.core.util.EpochMilli
 import com.realityexpander.tasky.core.util.UuidStr
 import okhttp3.MultipartBody
 import retrofit2.Response
@@ -61,7 +61,7 @@ interface TaskyApi {
     @GET("agenda")
     suspend fun getAgenda(
         @Query("timezone") timezone: TimeZoneStr,  // ex: "Europe/Berlin"
-        @Query("time") time: UtcMillis,            // epoch millis in UTC timeZone
+        @Query("time") time: EpochMilli,            // epoch millis in UTC timeZone
     ): Response<AgendaDayDTO>
 
     @POST("syncAgenda")

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/notifications/RemindAtAlarmManagerImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/notifications/RemindAtAlarmManagerImpl.kt
@@ -12,7 +12,7 @@ import com.realityexpander.tasky.core.presentation.broadcastReceivers.AlarmBroad
 import com.realityexpander.tasky.core.presentation.notifications.RemindAtNotificationManagerImpl.Companion.ALARM_NOTIFICATION_INTENT_ACTION_ALARM_TRIGGER
 import com.realityexpander.tasky.core.presentation.notifications.RemindAtNotificationManagerImpl.Companion.ALARM_NOTIFICATION_INTENT_EXTRA_AGENDA_ITEM
 import com.realityexpander.tasky.core.presentation.notifications.RemindAtNotificationManagerImpl.Companion.ALARM_NOTIFICATION_INTENT_EXTRA_ALARM_ID
-import com.realityexpander.tasky.core.util.toUtcMillis
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toZonedDateTime
 import logcat.logcat
 import java.time.ZonedDateTime
@@ -38,7 +38,7 @@ class RemindAtAlarmManagerImpl @Inject constructor(
         // Only include upcoming `Remind At` items (RemindAt is in the future)
         val futureAgendaItems =
             agendaItems.filter {
-                it.remindAtTime.toUtcMillis() >= ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toUtcMillis()
+                it.remindAt.toEpochMilli() >= ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS).toEpochMilli()
             }
 
         if (futureAgendaItems.isEmpty()) {
@@ -151,7 +151,7 @@ class RemindAtAlarmManagerImpl @Inject constructor(
             )
         val alarmClockInfo =
             AlarmManager.AlarmClockInfo(
-                agendaItem.remindAtTime.toUtcMillis(),
+                agendaItem.remindAt.toEpochMilli(),
                 mainActivityPendingIntent
             )
 

--- a/app/src/main/java/com/realityexpander/tasky/core/presentation/notifications/RemindAtNotificationManagerImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/presentation/notifications/RemindAtNotificationManagerImpl.kt
@@ -30,8 +30,8 @@ import com.realityexpander.tasky.agenda_feature.presentation.common.enums.toAgen
 import com.realityexpander.tasky.core.presentation.broadcastReceivers.CompleteTaskBroadcastReceiver
 import com.realityexpander.tasky.core.presentation.util.getBitmapFromVectorDrawable
 import com.realityexpander.tasky.core.util.UuidStr
+import com.realityexpander.tasky.core.util.toEpochMilli
 import com.realityexpander.tasky.core.util.toIntegerHashCodeOfUUIDString
-import com.realityexpander.tasky.core.util.toUtcMillis
 import com.realityexpander.tasky.core.util.toZonedDateTime
 import logcat.logcat
 import java.time.format.DateTimeFormatter
@@ -80,7 +80,7 @@ class RemindAtNotificationManagerImpl(val context: Context) : IRemindAtNotificat
                     itemUuidStr = item.id,
                     title = item.title,
                     description = item.description,
-                    startDateTimeUtcMillis = item.startTime.toUtcMillis()
+                    startDateTimeUtcMillis = item.startTime.toEpochMilli()
                 )
             }
         }

--- a/app/src/main/java/com/realityexpander/tasky/core/util/Constants.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/util/Constants.kt
@@ -1,8 +1,5 @@
 package com.realityexpander.tasky.core.util
 
-typealias UtcMillis = Long
-typealias UtcSeconds = Long
-
 const val DAY_IN_SECONDS = 86400
 
 const val UPLOAD_IMAGE_MAX_SIZE = 1_000_000 // 1 MB

--- a/app/src/main/java/com/realityexpander/tasky/core/util/UTCtoZonedDateTimeExtensions.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/util/UTCtoZonedDateTimeExtensions.kt
@@ -5,11 +5,15 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
-fun ZonedDateTime.toUtcMillis(): UtcMillis {
+typealias EpochMilli = Long
+typealias EpochSecond = Long
+typealias ZonedDateTimeStr = String
+
+fun ZonedDateTime.toEpochMilli(): EpochMilli {
     return this.toOffsetDateTime().toInstant().toEpochMilli()
 }
 
-fun UtcMillis.toZonedDateTime(zoneId: String = ZoneId.systemDefault().id): ZonedDateTime {
+fun EpochMilli.toZonedDateTime(zoneId: String = ZoneId.systemDefault().id): ZonedDateTime {
     return ZonedDateTime.ofInstant(
         Instant.ofEpochMilli(this),
         ZoneId.of(zoneId)

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -2,9 +2,9 @@ package com.realityexpander.tasky.di
 
 import android.content.Context
 import androidx.room.Room
-import com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
-import com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls.ReminderRepositoryImpl
-import com.realityexpander.remindery.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls.ReminderApiImpl
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls.ReminderRepositoryImpl
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls.ReminderApiImpl
 import com.realityexpander.tasky.agenda_feature.data.repositories.TaskyDatabase
 import com.realityexpander.tasky.agenda_feature.data.repositories.agendaRepository.agendaRepositoryImpls.AgendaRepositoryImpl
 import com.realityexpander.tasky.agenda_feature.data.repositories.agendaRepository.remote.AgendaApiImpl


### PR DESCRIPTION
* Refactor to only have `RemindAt` to be a single type (`ZonedDateTime`) in the domain layer
* Added `remindAtMilli` to DTO types 
* Attempted to refactor database TypeConverter to  use string primitve version of `ZonedDateTime` and found that SQL-queries must be based on primitive values, so dates must be stored as `long` for the comparisons to succeed.
* Refactor for more hierarchy and use of interfaces but less use of `@Ignore` and `@Transient`