### PR TITLE
0047-refactor-worker-starter  

### DIFF
--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/workers/IStartWorker.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/common/workers/IStartWorker.kt
@@ -1,0 +1,5 @@
+package com.realityexpander.tasky.agenda_feature.data.common.workers
+
+interface IStartWorker {
+    fun startWorker()
+}

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepositoryImpl.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/data/repositories/agendaRepository/agendaRepositoryImpls/AgendaRepositoryImpl.kt
@@ -287,6 +287,17 @@ class AgendaRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun clearAllAgendaItemsLocally(): ResultUiText<Void> {
+        return if (
+            clearAllEventsLocally() is ResultUiText.Success
+            && clearAllTasksLocally() is ResultUiText.Success
+            && clearAllRemindersLocally() is ResultUiText.Success
+        )
+            ResultUiText.Success(null)
+        else
+            ResultUiText.Error(UiText.Res(R.string.agenda_error, "clearAllAgendaItemsLocally"))
+    }
+
     ///////////////////////////////////////////////
     // • EVENT
 
@@ -388,7 +399,7 @@ class AgendaRepositoryImpl @Inject constructor(
         return reminderRepository.deleteReminder(reminder)
     }
 
-    override suspend fun clearAllRemindersLocal(): ResultUiText<Void> {
+    override suspend fun clearAllRemindersLocally(): ResultUiText<Void> {
         return reminderRepository.clearAllRemindersLocally()
     }
 

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/IAgendaRepository.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/domain/IAgendaRepository.kt
@@ -16,6 +16,7 @@ interface IAgendaRepository {
     suspend fun syncAgenda(): ResultUiText<Void>
     suspend fun updateLocalAgendaDayFromRemote(dateTime: ZonedDateTime): ResultUiText<Unit>
     fun getLocalAgendaItemsWithRemindAtInDateTimeRangeFlow(startDateTime: ZonedDateTime, endDateTime: ZonedDateTime): Flow<List<AgendaItem>>
+    suspend fun clearAllAgendaItemsLocally(): ResultUiText<Void>
 
     // • Event Repository
     suspend fun createEvent(event: AgendaItem.Event, isRemoteOnly: Boolean = false): ResultUiText<AgendaItem.Event>
@@ -40,5 +41,5 @@ interface IAgendaRepository {
     suspend fun getReminder(reminderId: ReminderId, isLocalOnly: Boolean = false): AgendaItem.Reminder?
     suspend fun updateReminder(reminder: AgendaItem.Reminder, isRemoteOnly: Boolean = false): ResultUiText<Void>
     suspend fun deleteReminder(reminder: AgendaItem.Reminder): ResultUiText<Void>
-    suspend fun clearAllRemindersLocal(): ResultUiText<Void>
+    suspend fun clearAllRemindersLocally(): ResultUiText<Void>
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.work.WorkManager
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.EmptyDestinationsNavigator
@@ -49,9 +48,6 @@ import com.realityexpander.tasky.agenda_feature.common.util.EventId
 import com.realityexpander.tasky.agenda_feature.common.util.ReminderId
 import com.realityexpander.tasky.agenda_feature.common.util.TaskId
 import com.realityexpander.tasky.agenda_feature.data.common.utils.getDateForDayOffset
-import com.realityexpander.tasky.agenda_feature.data.common.workers.RefreshAgendaWeekWorker
-import com.realityexpander.tasky.agenda_feature.data.common.workers.SyncAgendaWorker
-import com.realityexpander.tasky.agenda_feature.data.common.workers.TASKY_WORKERS_TAG
 import com.realityexpander.tasky.agenda_feature.domain.AgendaItem
 import com.realityexpander.tasky.agenda_feature.presentation.agenda_screen.AgendaScreenEvent.*
 import com.realityexpander.tasky.agenda_feature.presentation.common.MenuItem
@@ -73,7 +69,6 @@ import com.vanpra.composematerialdialogs.datetime.date.datepicker
 import com.vanpra.composematerialdialogs.rememberMaterialDialogState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import logcat.logcat
 import java.time.ZonedDateTime
 import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
@@ -317,18 +312,6 @@ fun AgendaScreenContent(
             is OneTimeEvent.NavigateToEditReminder -> {
                 navigateToReminderScreen(oneTimeEvent.reminderId, true)
             }
-
-            // • WORKERS
-            OneTimeEvent.StartWorkers -> {
-                logcat { "OneTimeEvent.StartWorkers: starting Tasky workers" }
-                SyncAgendaWorker.startWorker(context)
-                RefreshAgendaWeekWorker.startWorker(context)
-            }
-            OneTimeEvent.StopWorkers -> {
-                logcat { "OneTimeEvent.StopWorkers: stopping Tasky workers" }
-                WorkManager.getInstance(context).cancelAllWorkByTag(TASKY_WORKERS_TAG)
-            }
-
             is OneTimeEvent.ShowToast -> {
                 Toast.makeText(
                     context,

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreenEvent.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaScreenEvent.kt
@@ -64,9 +64,5 @@ sealed interface AgendaScreenEvent {
         object NavigateToCreateReminder : AgendaScreenEvent, OneTimeEvent
         data class NavigateToOpenReminder(val reminderId: TaskId) : AgendaScreenEvent, OneTimeEvent
         data class NavigateToEditReminder(val reminderId: TaskId) : AgendaScreenEvent, OneTimeEvent
-
-        // • Workers
-        object StartWorkers : OneTimeEvent
-        object StopWorkers : OneTimeEvent
     }
 }

--- a/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
+++ b/app/src/main/java/com/realityexpander/tasky/agenda_feature/presentation/agenda_screen/AgendaViewModel.kt
@@ -56,6 +56,7 @@ class AgendaViewModel @Inject constructor(
     private val _currentDate = MutableStateFlow(selectedDate)
     private val _selectedDayIndex = MutableStateFlow(selectedDayIndex)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val onlineState = connectivityObserver.onlineStateFlow.mapLatest { it }
 
     @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class) // for .flatMapLatest, .flattenMerge

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/IAuthApi.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/IAuthApi.kt
@@ -1,12 +1,12 @@
 package com.realityexpander.tasky.auth_feature.data.repository.remote
 
 import com.realityexpander.tasky.auth_feature.data.repository.remote.DTOs.auth.AuthInfoDTO
-import com.realityexpander.tasky.auth_feature.data.repository.remote.util.createAuthorizationHeader
 import com.realityexpander.tasky.core.util.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import logcat.logcat
 
+@Suppress("RemoveRedundantQualifierName", "RedundantCompanionReference")
 interface IAuthApi {
     suspend fun login(
         email: Email,
@@ -27,6 +27,7 @@ interface IAuthApi {
     )
 
     fun setAuthToken(authToken: AuthToken?) {
+
         IAuthApi.Companion.authToken = authToken
     }
 
@@ -60,11 +61,11 @@ interface IAuthApi {
             }
         }
 
+        fun createBearerTokenString(authToken: String?): String {
+            return "Bearer ${authToken ?: "NULL_AUTH_TOKEN"}"
+        }
+
         var authToken: String? = null
         var authUserId: UserId? = null
-
-        var authorizationHeader: String? = null
-            private set // only allow generating from Companion.authToken
-            get() = createAuthorizationHeader(Companion.authToken)
     }
 }

--- a/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/util/createAuthorizationHeader.kt
+++ b/app/src/main/java/com/realityexpander/tasky/auth_feature/data/repository/remote/util/createAuthorizationHeader.kt
@@ -1,5 +1,0 @@
-package com.realityexpander.tasky.auth_feature.data.repository.remote.util
-
-fun createAuthorizationHeader(authToken: String?): String {
-    return "Bearer ${authToken ?: "NULL_AUTH_TOKEN"}"
-}

--- a/app/src/main/java/com/realityexpander/tasky/core/data/remote/TaskyApi.kt
+++ b/app/src/main/java/com/realityexpander/tasky/core/data/remote/TaskyApi.kt
@@ -12,7 +12,7 @@ import com.realityexpander.tasky.agenda_feature.data.repositories.syncRepository
 import com.realityexpander.tasky.agenda_feature.data.repositories.taskRepository.remote.DTOs.TaskDTO
 import com.realityexpander.tasky.auth_feature.data.repository.remote.DTOs.auth.ApiCredentialsDTO
 import com.realityexpander.tasky.auth_feature.data.repository.remote.DTOs.auth.AuthInfoDTO
-import com.realityexpander.tasky.auth_feature.data.repository.remote.util.createAuthorizationHeader
+import com.realityexpander.tasky.auth_feature.data.repository.remote.IAuthApi.Companion.createBearerTokenString
 import com.realityexpander.tasky.core.util.AuthToken
 import com.realityexpander.tasky.core.util.Email
 import com.realityexpander.tasky.core.util.EpochMilli
@@ -48,7 +48,7 @@ interface TaskyApi {
     @GET("authenticate")
     suspend fun authenticateAuthToken(
         authToken: AuthToken?,
-        @Header("Authorization") authorizationHeader: String = createAuthorizationHeader(authToken),
+        @Header("Authorization") authorizationHeader: String = createBearerTokenString(authToken),
     ): Response<Void>
 
     @GET("logout")

--- a/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/AppModule.kt
@@ -1,10 +1,11 @@
 package com.realityexpander.tasky.di
 
+import android.app.Application
 import android.content.Context
 import androidx.room.Room
-import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
-import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls.ReminderRepositoryImpl
-import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls.ReminderApiImpl
+import androidx.work.WorkManager
+import com.realityexpander.tasky.agenda_feature.data.common.workers.RefreshAgendaWeekWorker
+import com.realityexpander.tasky.agenda_feature.data.common.workers.SyncAgendaWorker
 import com.realityexpander.tasky.agenda_feature.data.repositories.TaskyDatabase
 import com.realityexpander.tasky.agenda_feature.data.repositories.agendaRepository.agendaRepositoryImpls.AgendaRepositoryImpl
 import com.realityexpander.tasky.agenda_feature.data.repositories.agendaRepository.remote.AgendaApiImpl
@@ -17,7 +18,10 @@ import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepositor
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.local.IEventDao
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.IEventApi
 import com.realityexpander.tasky.agenda_feature.data.repositories.eventRepository.remote.eventApi.eventApiImpls.EventApiImpl
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.local.IReminderDao
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.reminderRepositoryImpls.ReminderRepositoryImpl
 import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.IReminderApi
+import com.realityexpander.tasky.agenda_feature.data.repositories.reminderRepository.remote.reminderApi.reminderApiImpls.ReminderApiImpl
 import com.realityexpander.tasky.agenda_feature.data.repositories.syncRepository.ISyncRepository
 import com.realityexpander.tasky.agenda_feature.data.repositories.syncRepository.local.ISyncDao
 import com.realityexpander.tasky.agenda_feature.data.repositories.syncRepository.remote.ISyncApi
@@ -57,6 +61,33 @@ const val USE_FAKE_REPOSITORY = false
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
+
+    /////////// WORK MANAGER ///////////
+
+    @Provides
+    @Singleton
+    @Named("WorkerController")
+    fun provideWorkManager(
+        application: Application
+    ): WorkManager {
+        return WorkManager.getInstance(application)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSyncAgendaWorkerStarter(
+        @ApplicationContext context: Context
+    ): SyncAgendaWorker.WorkerStarter {
+        return SyncAgendaWorker.WorkerStarter(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRefreshAgendaWeekWorkerStarter(
+        @ApplicationContext context: Context
+    ): RefreshAgendaWeekWorker.WorkerStarter {
+        return RefreshAgendaWeekWorker.WorkerStarter(context)
+    }
 
     /////////// DATABASE ///////////
 

--- a/app/src/main/java/com/realityexpander/tasky/di/NetworkingModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/NetworkingModule.kt
@@ -103,7 +103,7 @@ object NetworkingModule {
                 else print(message)
 
                 if (message.length > 500) {
-                    print("=== ... ${message.takeLast(message.length - 300)}")
+                    print("=== ...${message.takeLast(message.length - 300)}")
                     return print("=== ${message.length - 500} more characters ===")
                 }
             }

--- a/app/src/main/java/com/realityexpander/tasky/di/NetworkingModule.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/NetworkingModule.kt
@@ -5,7 +5,7 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import com.realityexpander.tasky.BuildConfig
 import com.realityexpander.tasky.auth_feature.data.repository.local.IAuthDao
 import com.realityexpander.tasky.auth_feature.data.repository.remote.IAuthApi
-import com.realityexpander.tasky.auth_feature.data.repository.remote.util.createAuthorizationHeader
+import com.realityexpander.tasky.auth_feature.data.repository.remote.IAuthApi.Companion.createBearerTokenString
 import com.realityexpander.tasky.core.data.remote.TaskyApi
 import dagger.Module
 import dagger.Provides
@@ -75,7 +75,7 @@ object NetworkingModule {
                     authDao.getAuthToken() // if invalid, attempt to fetch AuthToken from the AuthDao
                 }?.let { authToken ->
                     requestBuilder
-                        .addHeader("Authorization", createAuthorizationHeader(authToken))
+                        .addHeader("Authorization", createBearerTokenString(authToken))
                 }
 
                 val request = requestBuilder

--- a/app/src/main/java/com/realityexpander/tasky/di/WorkManagerInitializer.kt
+++ b/app/src/main/java/com/realityexpander/tasky/di/WorkManagerInitializer.kt
@@ -9,7 +9,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import logcat.logcat
 import javax.inject.Singleton
 
 @Module
@@ -21,8 +20,6 @@ object WorkManagerInitializer : Initializer<WorkManager> {
     override fun create(@ApplicationContext context: Context): WorkManager {
         val configuration = Configuration.Builder().build()
         WorkManager.initialize(context, configuration)
-
-        logcat {"WorkManager initialized by Hilt" }
         return WorkManager.getInstance(context)
     }
 


### PR DESCRIPTION
* Refactor to have workers start-up from VM by injecting the `WorkManager` and `StartWorker`
* Cant `@Inject` a regular worker directly, as Hilt doesnt support `@AssistedInject`, so made a separate `@Provides` to just inject the `StartWorker` fun.